### PR TITLE
[feature/15] portal 예시코드

### DIFF
--- a/frontend/client/public/index.html
+++ b/frontend/client/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="portal"></div>
   </body>
 </html>

--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React from 'react';
 
-import { Routes, Router, Route, Link, useParams } from "./lib/CustomRouter";
+import { Routes, Router, Route, Link, useParams } from './lib/CustomRouter';
+import TestModal from './portal/TestModal/TestModal';
 
 function Products() {
   return (
@@ -37,6 +38,7 @@ export default function App() {
       <Routes>
         <Route path="/products/:id">
           <Product />
+          <TestModal />
         </Route>
         <Route path="/">
           <Products />

--- a/frontend/client/src/portal/TestModal/TestModal.tsx
+++ b/frontend/client/src/portal/TestModal/TestModal.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import Portal from '../portal';
+
+const Container = styled.div`
+  position: fixed;
+  z-index: 1000;
+  text-align: center;
+  background-color: #00000080;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const Content = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  height: 60%;
+  margin: auto;
+  background-color: white;
+  border-radius: 12px;
+`;
+const TestModal = () => {
+  return (
+    <Portal>
+      <Container>
+        <Content>이것은 Test Modal 입니다.</Content>
+      </Container>
+    </Portal>
+  );
+};
+
+export default TestModal;

--- a/frontend/client/src/portal/portal.tsx
+++ b/frontend/client/src/portal/portal.tsx
@@ -1,8 +1,8 @@
-import { memo } from "react";
-import ReactDOM from "react-dom";
+import { memo } from 'react';
+import ReactDOM from 'react-dom';
 
 const Portal = memo(({ children }) => {
-  const el = document.getElementById("portal") as HTMLElement;
+  const el = document.getElementById('portal') as HTMLElement;
   return ReactDOM.createPortal(children, el);
 });
 


### PR DESCRIPTION

화면에 그려지는 root 외에 같은 depth의 id = portal 을 가지는 <div>에 그려주는 역할을 하는 것이 portal입니다.

portal을 이용해서 modal을 구현한 예제 코드를 첨가하였습니다.

portal로 감싸주면,  감싸진 해당 컴포넌트는 portal 아래에서 그려지는 구조입니다.
[portal 공식문서](https://ko.reactjs.org/docs/portals.html)

