### PR TITLE
[feature/23] Client App Jest 테스트 검사를 위한  git action 스크립트 추가

### DIFF
--- a/.github/workflows/client-test-actions.yaml
+++ b/.github/workflows/client-test-actions.yaml
@@ -1,0 +1,23 @@
+name: Clinet App CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install jest -g
+      - run: npm install
+        working-directory: ./frontend/client
+      - run: npm run test
+        working-directory: ./frontend/client


### PR DESCRIPTION
## :bookmark_tabs: 제목

CI(Continuous Integration)을 위해 Client App 의 jest 테스트를 통과하는 Git Action을 추가했습니다.

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

린트관련해서도 gitaction을 만들면 좋을 듯 합니다.

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] `.github/workflows/client-test-actions.yaml`

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아마 gitaction은 추후 CI/CD를 위해 미리 공부를 해두는게 좋을 듯합니다.
