### PR TITLE
[feature/23] Git Action event trigger 조건 수정

### DIFF
--- a/.github/workflows/client-test-actions.yaml
+++ b/.github/workflows/client-test-actions.yaml
@@ -1,6 +1,14 @@
 name: Clinet App CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   build:


### PR DESCRIPTION
## :bookmark_tabs: 제목

이전 Git Action `client-test-actions.yaml` 은 push 할 때마다 git action이 수행되었지만 `dev`, `main` 브랜치로 PR을 날리거나 Push를 했을 때 수행 되도록 재 수정 했습니다.

거의 1분이 걸리는데 `npm install`은 캐싱하는 방법을 찾아봐야할 것 같습니다.

결과는 스크린샷으로 남기겠습니다.

## 스크린샷

PR 을 올렸을 때 검사가 제대로 되는지

<img width="949" alt="스크린샷 2021-08-11 오후 2 48 15" src="https://user-images.githubusercontent.com/20085849/128976409-b93a5b31-8915-497e-b998-09a8559fb448.png">

통과했을 때때

<img width="950" alt="스크린샷 2021-08-11 오후 2 50 58" src="https://user-images.githubusercontent.com/20085849/128976447-61bd62b7-c077-4292-b92d-437d3447bf09.png">

