### PR TITLE
[feature/33] ThemeProvider 및 기본 theme 객체 추가

### DIFF
--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import GlobalStyles from './GlobalStyles';
+import { ThemeProvider } from 'styled-components';
 import { Routes, Route } from './lib/CustomRouter';
 import Main from './pages/Main/Main';
+import theme from './theme/theme';
 
 export default function App() {
   return (
-    <>
+    <ThemeProvider theme={theme}>
       {/* TODO: Change Header Component */}
       <div>Header</div>
       <div>
@@ -16,6 +18,6 @@ export default function App() {
         </Routes>
       </div>
       <GlobalStyles />
-    </>
+    </ThemeProvider>
   );
 }

--- a/frontend/client/src/theme/theme.ts
+++ b/frontend/client/src/theme/theme.ts
@@ -1,0 +1,18 @@
+const theme = {
+  primary: '#2AC1BC',
+  lightPrimary: '#A0E1E0',
+  darkPrimary: '#219A95',
+
+  error: '#F45452',
+  warning: '#F45452',
+  cancle: '#F45452',
+
+  titleActive: '#1E2222',
+  label: '#8D9393',
+  placeholder: '#C1C5C5',
+  dustWhite: '#F5F5F5',
+  offWhite: '#FCFCFC',
+  line: '#CCD3D3',
+};
+
+export default theme;


### PR DESCRIPTION
## :bookmark_tabs: 제목

ThemeProvider 및 기본 theme 객체 추가
## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] ThemeProvider 추가
- [x] 기본 theme 객체 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ThemeProvider의 하위 styled template literal에서 background-color: ${(props) => props.theme.titleActive} 와 같이 사용할 수 있습니다.