### PR TITLE
[feature/18] User 엔티티 수정

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -8,4 +8,6 @@ export const databaseConfig = {
   port: Number(process.env.DATABASE_PORT as string) || 3306,
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
+  // TODO: 배포시 삭제
+  synchronize: true,
 };

--- a/backend/src/entity/User.ts
+++ b/backend/src/entity/User.ts
@@ -1,11 +1,4 @@
-import {
-  Column,
-  CreateDateColumn,
-  Entity,
-  OneToMany,
-  PrimaryGeneratedColumn,
-  UpdateDateColumn,
-} from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { Cart } from './Cart';
 import { OrderList } from './OrderList';
 import { UserAddress } from './UserAddress';
@@ -15,25 +8,31 @@ export class User {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id!: number;
 
-  @Column({ type: 'varchar', length: 10 })
+  @Column({ type: 'varchar', length: 100 })
+  githubId!: string;
+
+  @Column({ type: 'varchar', length: 10, nullable: true })
   name!: string;
 
-  @Column({ type: 'varchar', length: 60 })
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  email!: string;
+
+  @Column({ type: 'varchar', length: 60, nullable: true })
   password!: string;
 
-  @Column({ type: 'varchar', length: 20 })
+  @Column({ type: 'varchar', length: 20, nullable: true })
   phone!: string;
 
-  @Column({ type: 'boolean' })
+  @Column({ type: 'boolean', nullable: true })
   terms_agree!: boolean;
 
-  @Column({ type: 'boolean' })
+  @Column({ type: 'boolean', nullable: true })
   privacy_agree!: boolean;
 
-  @Column({ type: 'boolean' })
+  @Column({ type: 'boolean', nullable: true })
   third_party_agree!: boolean;
 
-  @Column({ type: 'boolean' })
+  @Column({ type: 'boolean', nullable: true })
   marketing_agree!: boolean;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp' })


### PR DESCRIPTION
## :bookmark_tabs: 제목

User 엔티티 수정 및 TypeORM 동기화 설정 추가했습니다!

User 엔티티는 githubId와 date 관련 컬럼만 Not null입니다.

100자 제한으로 email도 추가했으며, githubId도 100자 제한을 했는데 깃허브에서 회원가입시 100글자까지 유효성 검사를 통과하고 있어서 그렇게 설정했습니다 :)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?
