### PR TITLE
[feature/9] 상품 이미지 호버 효과와 최근상품리스트를 보여주는 사이드바 구현

### DIFF
--- a/frontend/client/package.json
+++ b/frontend/client/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "webpack serve --config webpack.dev.js --progress",
-    "build": "webpack --mode production",
+    "build": "webpack --config webpack.prod.js",
     "prestart": "npm build",
     "start": "npm run dev",
     "test": "jest",

--- a/frontend/client/src/components/Footer/Footer.tsx
+++ b/frontend/client/src/components/Footer/Footer.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// 상호 : (주)우아한형제들 대표 : 김범준 사업자등록번호 : 120-87-65763 통신판매업신고번호 : 2012-서울송파-0515 [사업자정보확인]
+// 팩스번호 : 050-605-0041 메일 : baemin_store@woowahan.com 배민문방구 인스타그램 : @baemin_store
+// 주소 : 서울특별시 송파구 위례성대로 2 장은빌딩  호스팅제공 : 엔에이치엔고도(주)
+// © Woowa Brothers Corp. All right Reserved
+
+const Footer: React.FC = () => {
+  return (
+    <FooterContainer>
+      <FooterInfoSection>
+        <FooterInfoList>
+          <dl>
+            <dt>상호 :</dt>
+            <dd>(주)건강한형제들 </dd>
+          </dl>
+          <dl>
+            <dt>대표 :</dt>
+            <dd>고우혁 권기석 신어진 손지호</dd>
+          </dl>
+        </FooterInfoList>
+        <FooterInfoList>
+          <dl>
+            <dt>팩스번호 :</dt>
+            <dd>000-000-000</dd>
+          </dl>
+          <dl>
+            <dt>메일 :</dt>
+            <dd>baemin_store@woowahan.com</dd>
+          </dl>
+          <dl>
+            <dt>주소 :</dt>
+            <dd>잠실 어딘가 </dd>
+          </dl>
+        </FooterInfoList>
+        <FooterInfoList>© Woowa Brothers Corp. All right Reserved</FooterInfoList>
+      </FooterInfoSection>
+    </FooterContainer>
+  );
+};
+
+export default Footer;
+
+const FooterContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 50px 0;
+`;
+
+const FooterInfoSection = styled.div`
+  width: 500px;
+`;
+
+const FooterInfoList = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 3px;
+
+  dl {
+    display: flex;
+    margin-right: 3px;
+    ::after {
+      content: '|';
+      padding: 0 5px;
+    }
+    dt,
+    dd {
+      padding: 1px;
+      background-color: #c0c0c0;
+    }
+  }
+`;

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -38,7 +38,11 @@ const GoodsItem: React.FC<Props> = ({
         {isNew && <NewTag />}
         {isSale && <SaleTag />}
       </TagContainer>
-      {thumbnailImg ? <GoodsImage src={thumbnailImg} /> : <GoodsEmptyImage />}
+
+      <GoodsImageContainer>
+        {thumbnailImg ? <GoodsImage src={thumbnailImg} /> : <GoodsEmptyImage />}
+      </GoodsImageContainer>
+
       {discountRate && discountRate > 0 ? <GoodsDiscountLabel> {discountRate} % </GoodsDiscountLabel> : ''}
       <GoodsTitle>{title}</GoodsTitle>
       <GoodsPriceLabel>{price} 원</GoodsPriceLabel>
@@ -53,6 +57,7 @@ const TagContainer = styled.div`
   top: 0;
   padding: 15px;
   width: 100%;
+  z-index: 1;
   & > *:not(:last-child) {
     margin-right: 10px;
   }
@@ -70,17 +75,55 @@ const GoodsItemContainer = styled.div`
   flex-direction: column;
 `;
 
-const GoodsEmptyImage = styled.div`
+interface GoodsEmptyImageProps {
+  theme: {
+    label: string;
+  };
+}
+const GoodsEmptyImage = styled.div<GoodsEmptyImageProps>`
   width: 100%;
   height: 350px;
-  background-color: #c0c0c0; // TODO: change const color
-  // TODO: backgrond-img;
+  opacity: 0.5;
+  background-color: ${(props) => props.theme.label};
+  // TODO: add backgrond-img;
+`;
+
+const GoodsImageContainer = styled.div`
+  width: 100%;
+  height: 350px;
+  overflow: hidden;
 `;
 
 const GoodsImage = styled.img`
   width: 100%;
-  height: 350px;
+  height: 100%;
   object-fit: cover;
+  transform: scale(1);
+  filter: blur(1px);
+  -webkit-filter: blur(1px);
+
+  &:hover {
+    opacity: 1;
+    transform: scale(1.1);
+    filter: blur(0px);
+    -webkit-filter: blur(0px);
+    animation-name: imgZoomEffect;
+    animation-duration: 0.2s;
+  }
+
+  @keyframes imgZoomEffect {
+    from {
+      filter: blur(0.5px);
+      -webkit-filter: blur(0.5px);
+      transform: scale(1);
+    }
+
+    to {
+      filter: blur(0px);
+      -webkit-filter: blur(0px);
+      transform: scale(1.1);
+    }
+  }
 `;
 
 const GoodsTitle = styled.strong`

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -55,14 +55,17 @@ const GoodsItem: React.FC<Props> = ({
         {thumbnailImg ? <GoodsImage src={thumbnailImg} /> : <GoodsEmptyImage />}
 
         {isHoverGoodsImage && (
-          <GoodsUtilBtnContainer>
-            <GoodsUtilBtn>
-              <BsHeart />
-            </GoodsUtilBtn>
-            <GoodsUtilBtn>
-              <BsFillBucketFill />
-            </GoodsUtilBtn>
-          </GoodsUtilBtnContainer>
+          <>
+            <GoodsImageOverlay />
+            <GoodsUtilBtnContainer>
+              <GoodsUtilBtn>
+                <BsHeart />
+              </GoodsUtilBtn>
+              <GoodsUtilBtn>
+                <BsFillBucketFill />
+              </GoodsUtilBtn>
+            </GoodsUtilBtnContainer>
+          </>
         )}
       </GoodsImageContainer>
 
@@ -106,7 +109,7 @@ interface GoodsEmptyImageProps {
 const GoodsEmptyImage = styled.div<GoodsEmptyImageProps>`
   width: 100%;
   height: 350px;
-  opacity: 0.5;
+  opacity: 0.8;
   background-color: ${(props) => props.theme.label};
   // TODO: add backgrond-img;
 `;
@@ -116,7 +119,37 @@ const GoodsImageContainer = styled.div`
   width: 100%;
   height: 350px;
   overflow: hidden;
-  border-radius: 3px;
+  border-radius: 8px;
+`;
+
+const GoodsImageOverlay = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  pointer-events: none;
+  width: 100%;
+  height: 350px;
+  opacity: 1;
+  transition: opacity 300ms ease;
+  background: linear-gradient(
+    180deg,
+    transparent 62%,
+    rgba(0, 0, 0, 0.00345888) 63.94%,
+    rgba(0, 0, 0, 0.014204) 65.89%,
+    rgba(0, 0, 0, 0.0326639) 67.83%,
+    rgba(0, 0, 0, 0.0589645) 69.78%,
+    rgba(0, 0, 0, 0.0927099) 71.72%,
+    rgba(0, 0, 0, 0.132754) 73.67%,
+    rgba(0, 0, 0, 0.177076) 75.61%,
+    rgba(0, 0, 0, 0.222924) 77.56%,
+    rgba(0, 0, 0, 0.267246) 79.5%,
+    rgba(0, 0, 0, 0.30729) 81.44%,
+    rgba(0, 0, 0, 0.341035) 83.39%,
+    rgba(0, 0, 0, 0.367336) 85.33%,
+    rgba(0, 0, 0, 0.385796) 87.28%,
+    rgba(0, 0, 0, 0.396541) 89.22%,
+    rgba(0, 0, 0, 0.4) 91.17%
+  );
 `;
 
 const GoodsImage = styled.img`

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -1,7 +1,10 @@
 import { usePushHistory } from '@src/lib/CustomRouter';
 import React from 'react';
 import styled from 'styled-components';
+import { BsHeartFill, BsHeart, BsFillBucketFill } from 'react-icons/bs';
 import { BestTag, GreenTag, NewTag, SaleTag } from '../Tag';
+import { useCallback } from 'react';
+import { useState } from 'react';
 
 interface Props {
   id: number;
@@ -30,6 +33,15 @@ const GoodsItem: React.FC<Props> = ({
   const handleClickGoodsItem = (e: React.MouseEvent) => {
     push('/detail/' + id);
   };
+  const [isHoverGoodsImage, setIsHoverGoodsImage] = useState<boolean>(false);
+
+  const handleOnMouseEnter = useCallback((e) => {
+    setIsHoverGoodsImage(true);
+  }, []);
+
+  const handleOnMouseLeave = useCallback((e) => {
+    setIsHoverGoodsImage(false);
+  }, []);
   return (
     <GoodsItemContainer onClick={handleClickGoodsItem}>
       <TagContainer>
@@ -39,8 +51,19 @@ const GoodsItem: React.FC<Props> = ({
         {isSale && <SaleTag />}
       </TagContainer>
 
-      <GoodsImageContainer>
+      <GoodsImageContainer onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
         {thumbnailImg ? <GoodsImage src={thumbnailImg} /> : <GoodsEmptyImage />}
+
+        {isHoverGoodsImage && (
+          <GoodsUtilBtnContainer>
+            <GoodsUtilBtn>
+              <BsHeart />
+            </GoodsUtilBtn>
+            <GoodsUtilBtn>
+              <BsFillBucketFill />
+            </GoodsUtilBtn>
+          </GoodsUtilBtnContainer>
+        )}
       </GoodsImageContainer>
 
       {discountRate && discountRate > 0 ? <GoodsDiscountLabel> {discountRate} % </GoodsDiscountLabel> : ''}
@@ -89,9 +112,11 @@ const GoodsEmptyImage = styled.div<GoodsEmptyImageProps>`
 `;
 
 const GoodsImageContainer = styled.div`
+  position: relative;
   width: 100%;
   height: 350px;
   overflow: hidden;
+  border-radius: 3px;
 `;
 
 const GoodsImage = styled.img`
@@ -124,6 +149,38 @@ const GoodsImage = styled.img`
       transform: scale(1.1);
     }
   }
+`;
+
+const GoodsUtilBtnContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  bottom: 0px;
+  left: 50%;
+  transform: translate(-50%, -10px);
+  animation-name: springEffect;
+  animation-duration: 0.5s;
+  @keyframes springEffect {
+    from {
+      transform: translate(-50%, 0);
+    }
+
+    to {
+      transform: translate(-50%, -10px);
+    }
+  }
+`;
+
+const GoodsUtilBtn = styled.button`
+  width: 30px;
+  height: 30px;
+  border-radius: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  background-color: white;
+  margin-right: 3px;
 `;
 
 const GoodsTitle = styled.strong`

--- a/frontend/client/src/components/Tag/index.tsx
+++ b/frontend/client/src/components/Tag/index.tsx
@@ -1,28 +1,30 @@
 import React from 'react';
 import styled from 'styled-components';
+import { FaLeaf, FaThumbsUp } from 'react-icons/fa';
+import { AiFillAlert, AiFillDollarCircle } from 'react-icons/ai';
 
 export const GreenTag: React.FC = () => (
   <TagWrapper fontColor={tagColors.white} bgColor={tagColors.naturalGreen}>
-    GREEN
+    GREEN <FaLeaf />
   </TagWrapper>
 );
 
 export const NewTag: React.FC = () => (
   <TagWrapper fontColor={tagColors.white} bgColor={tagColors.splashBlue}>
-    NEW
+    NEW <AiFillAlert />
   </TagWrapper>
 );
 
 // TODO: icon
 export const BestTag: React.FC = () => (
   <TagWrapper fontColor={tagColors.white} bgColor={tagColors.originalBlack}>
-    BEST
+    BEST <FaThumbsUp />
   </TagWrapper>
 );
 
 export const SaleTag: React.FC = () => (
   <TagWrapper fontColor={tagColors.white} bgColor={tagColors.originalRed}>
-    SALE
+    SALE <AiFillDollarCircle />
   </TagWrapper>
 );
 
@@ -40,10 +42,13 @@ interface TagWrapperProps {
 }
 
 const TagWrapper = styled.div<TagWrapperProps>`
+  display: flex;
+  align-items: center;
   border-radius: 8px;
   padding: 5px;
   color: ${(props) => props.fontColor ?? 'white'};
   background-color: ${(props) => props.bgColor ?? 'black'};
   font-size: 16px;
-  font-weight: 500;
+  font-weight: 300;
+  user-select: none;
 `;

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -5,6 +5,7 @@ import GoodsSection from '@src/components/GoodsSection/GoodsSection';
 import PromotionCarousel from '@src/components/PromotionCarousel/PromotionCarousel';
 import { Promotion } from '@src/types/Promotion';
 import Footer from '@src/components/Footer/Footer';
+import SideBar from './SideBar/SideBar';
 
 const mockProductImagePath =
   'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg';
@@ -76,6 +77,7 @@ const Main = () => (
       <GoodsSection sectionTitle='잘나가요' goodsList={mock_best_products} />
       <GoodsSection sectionTitle='새로 나왔어요' goodsList={mock_new_products} />
     </MainContentContainer>
+    <SideBar goodsList={mock_best_products} />
     <FooterContainer>
       <Footer />
     </FooterContainer>
@@ -96,4 +98,5 @@ const FooterContainer = styled.div<FooterContainerProps>`
   width: 100%;
   background-color: ${(props) => props.theme.dustWhite};
 `;
+
 export default Main;

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -4,6 +4,7 @@ import { ThumbnailGoods } from '@src/types/Goods';
 import GoodsSection from '@src/components/GoodsSection/GoodsSection';
 import PromotionCarousel from '@src/components/PromotionCarousel/PromotionCarousel';
 import { Promotion } from '@src/types/Promotion';
+import Footer from '@src/components/Footer/Footer';
 
 const mockProductImagePath =
   'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg';
@@ -75,6 +76,9 @@ const Main = () => (
       <GoodsSection sectionTitle='잘나가요' goodsList={mock_best_products} />
       <GoodsSection sectionTitle='새로 나왔어요' goodsList={mock_new_products} />
     </MainContentContainer>
+    <FooterContainer>
+      <Footer />
+    </FooterContainer>
   </>
 );
 
@@ -83,4 +87,13 @@ const MainContentContainer = styled.div`
   margin: 0 auto;
 `;
 
+interface FooterContainerProps {
+  theme: {
+    dustWhite: string;
+  };
+}
+const FooterContainer = styled.div<FooterContainerProps>`
+  width: 100%;
+  background-color: ${(props) => props.theme.dustWhite};
+`;
 export default Main;

--- a/frontend/client/src/pages/Main/SideBar/SideBar.spec.tsx
+++ b/frontend/client/src/pages/Main/SideBar/SideBar.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { render, cleanup } from '@testing-library/react';
+
+import Sidebar, { COUNT_OF_SHOWN_GOODS } from './SideBar';
+import { Goods } from 'src/types/Goods';
+
+describe('Goods Section Component', () => {
+  it('사이드바는 최근 본 상품이 4개 이상일 때, 항상 4개의 이미지만을 보여줘야합니다.', () => {
+    const mock_goods: Goods[] = [
+      { id: 1, thumbnailImg: 'test_url', title: '맥쥬짠1', price: 10000 },
+      { id: 2, thumbnailImg: 'test_url', title: '맥쥬짠2', price: 20000 },
+      { id: 3, thumbnailImg: 'test_url', title: '맥쥬짠3', price: 30000 },
+      { id: 4, thumbnailImg: 'test_url', title: '맥쥬짠4', price: 40000 },
+    ];
+    const wrapper = render(<Sidebar goodsList={mock_goods} />);
+    expect(wrapper.queryAllByRole('img').length).toBe(COUNT_OF_SHOWN_GOODS);
+  });
+
+  it('사이드바는 최근 본 상품이 4개 이하일때, 상품을 모두 보여줘야합니다.', () => {
+    const mock_goods: Goods[] = [
+      { id: 1, thumbnailImg: 'test_url', title: '맥쥬짠1', price: 10000 },
+      { id: 2, thumbnailImg: 'test_url', title: '맥쥬짠2', price: 20000 },
+    ];
+    const wrapper = render(<Sidebar goodsList={mock_goods} />);
+    expect(wrapper.queryAllByRole('img').length).toBe(2);
+  });
+
+  it('이미지 url이 없는 상품은 no image div를 보여준다', () => {
+    const mock_goods: Goods[] = [
+      { id: 1, thumbnailImg: '', title: 'no image goods', price: 10000 },
+      { id: 2, thumbnailImg: 'test_url', title: '맥쥬짠2', price: 20000 },
+    ];
+    const wrapper = render(<Sidebar goodsList={mock_goods} />);
+    expect(wrapper.queryAllByRole('img').length).toBe(1);
+  });
+
+  // TODO: 사이드바 버튼했을 때 이미지를 어떻게 구분하지?
+
+  afterAll(cleanup);
+});

--- a/frontend/client/src/pages/Main/SideBar/SideBar.tsx
+++ b/frontend/client/src/pages/Main/SideBar/SideBar.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
+import { AiFillCloseCircle } from 'react-icons/ai';
+import { ThumbnailGoods } from '@src/types/Goods';
+import { useRef } from 'react';
+import { useEffect } from 'react';
+interface SideBarProps {
+  goodsList?: ThumbnailGoods[];
+}
+
+const COUNT_OF_SHOWN_GOODS = 3;
+// TODO: SideBar도 Intersection Observer
+const SideBar: React.FC<SideBarProps> = ({ goodsList }) => {
+  const [recentGoods, setRecentGoods] = useState(goodsList ?? []);
+  const [recentGoodsIdx, setRecentGoodsIndx] = useState(0);
+  const handleUpList = () => {
+    if (recentGoodsIdx > 0) {
+      setRecentGoodsIndx(recentGoodsIdx - 1);
+    }
+  };
+  const handleDownList = () => {
+    if (recentGoodsIdx < recentGoods.length - 1) {
+      setRecentGoodsIndx(recentGoodsIdx + 1);
+    }
+  };
+
+  const handleDeleteRecentGoods = (id: number) => {
+    // TODO: Delete API
+    console.log('Delete goods -' + id);
+  };
+
+  return (
+    <>
+      <SideBarContainer>
+        <ArrowButton onClick={handleUpList}>
+          <FaArrowUp />
+        </ArrowButton>
+        <Splitter />
+        <RecentGoodsList>
+          {goodsList?.slice(recentGoodsIdx, recentGoodsIdx + COUNT_OF_SHOWN_GOODS).map((goods) => (
+            <GoodsThumbnailBox key={goods.id}>
+              {goods.thumbnailImg ? (
+                <GoodsThumbnail src={goods.thumbnailImg} />
+              ) : (
+                <EmptyGoodsThumbnail>No Image</EmptyGoodsThumbnail>
+              )}
+              <DeleteGoods onClick={() => handleDeleteRecentGoods(goods.id)}>
+                <AiFillCloseCircle size={20} />
+              </DeleteGoods>
+            </GoodsThumbnailBox>
+          ))}
+        </RecentGoodsList>
+        <Splitter />
+        <ArrowButton onClick={handleDownList}>
+          <FaArrowDown />
+        </ArrowButton>
+      </SideBarContainer>
+    </>
+  );
+};
+
+interface SideBarContainerProps {
+  theme: {
+    line: string;
+    offWhite: string;
+  };
+}
+
+const SideBarContainer = styled.div<SideBarContainerProps>`
+  position: fixed;
+  right: 0px;
+  top: 50%;
+  padding: 0px 10px;
+  width: 140px;
+  height: 350px;
+  transform: translate(0, -50%);
+  border-width: 1px;
+  border-style: solid;
+  border-color: ${(props) => props.theme.line};
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const RecentGoodsList = styled.ul`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  overflow-y: scroll;
+  padding: 5px 0px;
+`;
+
+const ArrowButton = styled.button`
+  border: none;
+  cursor: pointer;
+  background-color: transparent;
+  height: 30px;
+`;
+
+interface SplitterProps {
+  theme: {
+    line: string;
+  };
+}
+const Splitter = styled.span<SplitterProps>`
+  background-color: ${(props) => props.theme.line};
+  width: 100%;
+  height: 3px;
+`;
+
+interface GoodsThumbnailBoxProps {
+  theme: {
+    line: string;
+  };
+}
+const GoodsThumbnailBox = styled.div<GoodsThumbnailBoxProps>`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 85px;
+  height: 85px;
+  border: 2px solid transparent;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  &:hover {
+    border: 2px solid ${(props) => props.theme.line};
+  }
+`;
+
+const GoodsThumbnail = styled.img`
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  object-fit: contain;
+`;
+
+interface EmptyGoodsThumbnailProps {
+  theme: {
+    darkPrimary: string;
+  };
+}
+const EmptyGoodsThumbnail = styled.div<EmptyGoodsThumbnailProps>`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${(props) => props.theme.darkPrimary};
+  background-color: ${(props) => props.theme.dustWhite};
+  opacity: 0.5px;
+`;
+
+interface DeleteGoodsProps {
+  theme: {
+    line: string;
+  };
+}
+const DeleteGoods = styled.div<DeleteGoodsProps>`
+  position: absolute;
+  right: -10px;
+  top: -10px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background-color: white;
+  color: ${(props) => props.theme.line};
+  visibility: hidden;
+
+  ${GoodsThumbnailBox}:hover > & {
+    visibility: visible;
+  }
+
+  :hover {
+    transform: scale(1.2);
+  }
+`;
+export default SideBar;

--- a/frontend/client/src/pages/Main/SideBar/SideBar.tsx
+++ b/frontend/client/src/pages/Main/SideBar/SideBar.tsx
@@ -3,13 +3,12 @@ import styled from 'styled-components';
 import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
 import { AiFillCloseCircle } from 'react-icons/ai';
 import { ThumbnailGoods } from '@src/types/Goods';
-import { useRef } from 'react';
-import { useEffect } from 'react';
+
 interface SideBarProps {
   goodsList?: ThumbnailGoods[];
 }
 
-const COUNT_OF_SHOWN_GOODS = 3;
+export const COUNT_OF_SHOWN_GOODS = 3;
 // TODO: SideBar도 Intersection Observer
 const SideBar: React.FC<SideBarProps> = ({ goodsList }) => {
   const [recentGoods, setRecentGoods] = useState(goodsList ?? []);


### PR DESCRIPTION
## :bookmark_tabs: 제목

메인 화면에서 상품 이미지 호버효과와 최근 상품리스트를 보여주는 사이드바를 구현했습니다. (+ 푸터)

![product](https://user-images.githubusercontent.com/20085849/129181193-8c49e9c5-398d-422b-ab0a-f2a9ec3df426.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x]  Footer Component 구현
- [x] GoodsItem Component 구현
- [x] SideBar Component 구현

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 디자인적으로 개선할만한 내용들을 더 추가해볼만합니다. 추후에 UI/UX 관련해서 주말에 피그마 작업을 조금 해볼까합니다.
- Sidebar도 intersection observer를 적용해볼만합니다. 기석님 코드가 머지되면 참고해서 적용해보겠습니다.