### PR TITLE
[feature/77] Category API 구현

### DIFF
--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -1,12 +1,23 @@
 import { Request, Response } from 'express';
-import { CategoryService } from '../service/category.service';
+import CategoryService from '../service/category.service';
 
-async function createSubCategory(req: Request, res: Response) {
+async function createCategory(req: Request, res: Response) {
   const { parentId, name } = req.body;
-  const result = await CategoryService.createSubCategory(parentId, name);
-  res.status(200).json(result);
+  const result = await CategoryService.createCategory(name, parentId);
+  res.status(200).json({ result });
 }
 
-export const CategoryController = {
-  createSubCategory,
+async function getAllCategory(req: Request, res: Response) {
+  const categories = await CategoryService.getAllCategory();
+
+  res.status(200).json({
+    result: {
+      categories,
+    },
+  });
+}
+
+export default {
+  createCategory,
+  getAllCategory,
 };

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -12,7 +12,7 @@ import { Promotion } from './entity/Promotion';
 import { User } from './entity/User';
 import { UserAddress } from './entity/UserAddress';
 import { Wish } from './entity/Wish';
-import { CategoryRepository } from './repository/category.repository';
+import CategoryRepository from './repository/category.repository';
 import { UserRepository } from './repository/user.repository';
 import { UserAddressRepository } from './repository/user.address.repository';
 
@@ -41,8 +41,19 @@ export default async function () {
 async function populate() {
   await createDefaultUser('아이유');
   await createDefaultAddress();
-  const categories = ['문구', '잡화', '생필품'];
-  categories.forEach((name) => createCategory(name));
+
+  const categories = [
+    { name: 'A' },
+    { parent: 'A', name: 'A1' },
+    { parent: 'A', name: 'A2' },
+    { parent: 'A', name: 'A3' },
+    { name: 'B' },
+    { parent: 'B', name: 'B1' },
+    { parent: 'B', name: 'B2' },
+  ];
+  for (const category of categories) {
+    await createCategory(category.name, category.parent);
+  }
 }
 
 async function createDefaultUser(name: string) {
@@ -52,10 +63,25 @@ async function createDefaultUser(name: string) {
   }
 }
 
-async function createCategory(name: string) {
-  const res = await CategoryRepository.getCategoryByName(name);
-  if (!res) {
-    await CategoryRepository.createCategory(name);
+async function createCategory(name: string, parentCategoryName?: string) {
+  if (parentCategoryName) {
+    const parent = await CategoryRepository.getCategoryByName(parentCategoryName);
+    if (!parent) {
+      throw Error(
+        '존재하지않는 부모 카테고리를 가진 데이터를 넣을 수 없습니다. parentCategory Name: ' + parentCategoryName
+      );
+    }
+    const originCategory = await CategoryRepository.getCategoryByName(name);
+    if (!originCategory) {
+      const newCategory = await CategoryRepository.createSubCategory(name, parent.id);
+      console.log(`초기 카테고리 데이터 삽입 : name - ${newCategory.name}, parent - ${parent.name}`);
+    }
+  } else {
+    const originCategory = await CategoryRepository.getCategoryByName(name);
+    if (!originCategory) {
+      const newCategory = await CategoryRepository.createCategory(name);
+      console.log(`초기 카테고리 데이터 삽입 : name - ${newCategory.name}`);
+    }
   }
 }
 

--- a/backend/src/repository/category.repository.ts
+++ b/backend/src/repository/category.repository.ts
@@ -6,8 +6,8 @@ import { DatabaseError } from '../errors/base.error';
 async function createCategory(name: string): Promise<Category> {
   try {
     const categoryRepo = getRepository(Category);
-    const category = await categoryRepo.create({ name });
-    await categoryRepo.insert(category);
+    const category = categoryRepo.create({ name });
+    await categoryRepo.save(category);
     return category;
   } catch (err) {
     console.error(err);
@@ -15,12 +15,11 @@ async function createCategory(name: string): Promise<Category> {
   }
 }
 
-async function createSubCategory(parentId: number, name: string): Promise<Category> {
+async function createSubCategory(name: string, parentId: number): Promise<Category> {
   try {
-    await createCategory(name);
     const categoryRepo = getRepository(Category);
-    const category = await categoryRepo.create({ name, parent: parentId });
-    await categoryRepo.insert(category);
+    const category = categoryRepo.create({ name, parent: parentId });
+    await categoryRepo.save(category);
     return category;
   } catch (err) {
     console.error(err);
@@ -38,29 +37,18 @@ async function getCategoryByName(name: string): Promise<Category | undefined> {
   }
 }
 
-async function getAllCategories() {
+async function getAllCategories(): Promise<Category[]> {
   try {
     const categoryRepo = getRepository(Category);
     const categories = await categoryRepo.find();
-    const result = new Map();
-    categories.forEach((category) => {
-      if (!category.parent) {
-        result.set(category.id, {
-          ...category,
-          categories: [],
-        });
-      } else {
-        result.get(category.parent).categories.push(category);
-      }
-    });
-    return result.size ? Array.from(result) : null;
+    return categories;
   } catch (err) {
     console.error(err);
     throw new DatabaseError(CATEGORY_DB_ERROR);
   }
 }
 
-export const CategoryRepository = {
+export default {
   createCategory,
   createSubCategory,
   getCategoryByName,

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -1,8 +1,9 @@
 import express from 'express';
-import { CategoryController } from '../controller/category.controller';
+import CategoryController from '../controller/category.controller';
 import wrapAsync from '../utils/wrap-async';
 
 const router = express.Router();
 
-// router.get('/', wrapAsync(CategoryController.)) TODO: Get ALL 카테고리 연동
-router.post('/sub', wrapAsync(CategoryController.createSubCategory));
+router.get('/', wrapAsync(CategoryController.getAllCategory));
+router.post('/', wrapAsync(CategoryController.createCategory));
+export default router;

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -3,11 +3,12 @@ import express from 'express';
 import authRouter from './auth.router';
 import goodsRouter from './goods.router';
 import userRouter from './user.router';
+import categoryRouter from './category.router';
 
 const router = express.Router();
 
 router.use('/auth', authRouter);
 router.use('/goods', goodsRouter);
 router.use('/user', userRouter);
-
+router.use('/category', categoryRouter);
 export default router;

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -1,10 +1,47 @@
 import { Category } from '../entity/Category';
-import { CategoryRepository } from '../repository/category.repository';
+import { CategoryResponse } from '../types/response/category.response';
+import CategoryRepository from '../repository/category.repository';
 
-async function createSubCategory(parentId: number, name: string): Promise<Category> {
-  return await CategoryRepository.createSubCategory(parentId, name);
+async function createCategory(name: string, parentId?: number): Promise<Category> {
+  if (parentId) {
+    return await CategoryRepository.createSubCategory(name, parentId);
+  } else {
+    return await CategoryRepository.createCategory(name);
+  }
 }
 
-export const CategoryService = {
-  createSubCategory,
+async function getAllCategory(): Promise<CategoryResponse[]> {
+  const categories = await CategoryRepository.getAllCategories();
+  const categoryMap = new Map<number, CategoryResponse>();
+
+  // 최상위 카테고리 데이터 생성
+  categories
+    .filter((category) => !category.parent)
+    .forEach((parentCategory) => {
+      categoryMap.set(parentCategory.id, {
+        id: parentCategory.id,
+        name: parentCategory.name,
+        categories: [],
+      });
+    });
+
+  // 서브 카테고리 데이터 생성
+  categories
+    .filter((category) => category.parent !== undefined)
+    .forEach((category) => {
+      const parentCategoryResponse = categoryMap.get(category.parent);
+      if (parentCategoryResponse) {
+        parentCategoryResponse.categories?.push({
+          id: category.id,
+          name: category.name,
+        });
+      }
+    });
+
+  return Array.from(categoryMap.entries()).map(([_, value]) => value);
+}
+
+export default {
+  createCategory,
+  getAllCategory,
 };

--- a/backend/src/types/response/category.response.ts
+++ b/backend/src/types/response/category.response.ts
@@ -1,0 +1,5 @@
+export type CategoryResponse = {
+  id: number;
+  name: string;
+  categories?: CategoryResponse[];
+};

--- a/frontend/client/src/apis/base.ts
+++ b/frontend/client/src/apis/base.ts
@@ -1,3 +1,12 @@
 export interface APIResponse<T = any> {
   result: T;
 }
+
+export const checkedFetch: typeof fetch = async (input, init) => {
+  const response = await fetch(input, init);
+
+  if (!response.ok) {
+    throw Error('Request failed: ' + response.status);
+  }
+  return response;
+};

--- a/frontend/client/src/apis/categoryAPI.ts
+++ b/frontend/client/src/apis/categoryAPI.ts
@@ -1,0 +1,12 @@
+import { Category } from '@src/types/Category';
+import { APIResponse, checkedFetch } from './base';
+interface CategoryResponse {
+  categories: Category[];
+}
+export const getAllCategory = async (): Promise<APIResponse<CategoryResponse>> => {
+  const res = await checkedFetch(`/api/category`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return await res.json();
+};

--- a/frontend/client/src/components/Header/HeaderBottom/Category/Category.tsx
+++ b/frontend/client/src/components/Header/HeaderBottom/Category/Category.tsx
@@ -1,56 +1,47 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { debounce } from '@src/utils/debounce';
 import MainCategoryList from '@src/components/Header/HeaderBottom/Category/MainCategoryList/MainCategoryList';
 import SubCategoryList from '@src/components/Header/HeaderBottom/Category/SubCategoryList/SubCategoryList';
 import styled from 'styled-components';
-
-// TODO: API 연동 후 dummy Data 삭제
-const MAIN_CATEGORY = ['문구', '리빙', '책', '배민그린', '을지로에디션'];
-
-const SUB_CATEGORY = {
-  문구: ['문구1', '문구2', '문구3', '문구4', '문구5', '문구6'],
-  리빙: ['리빙1', '리빙2', '리빙3', '리빙4', '리빙5', '리빙6'],
-  책: ['책1', '책2', '책3', '책4', '책5', '책6'],
-  배민그린: ['배민그린1', '배민그린2', '배민그린3', '배민그린4', '배민그린5', '배민그린6'],
-  을지로에디션: [
-    '을지로에디션1',
-    '을지로에디션2',
-    '을지로에디션3',
-    '을지로에디션4',
-    '을지로에디션5',
-    '을지로에디션6',
-    '을지로에디션1',
-    '을지로에디션2',
-    '을지로에디션3',
-    '을지로에디션4',
-    '을지로에디션5',
-    '을지로에디션6',
-  ],
-};
-
-// TODO: 임시 데이터 타입 정의, DB에서 데이터 관리할 예정
-type MainCategory = '문구' | '리빙' | '책' | '배민그린' | '을지로에디션';
+import { getAllCategory } from '@src/apis/categoryAPI';
+import { Category } from '@src/types/Category';
 
 const Category = () => {
-  const [hovered, setHovered] = useState<MainCategory>(MAIN_CATEGORY[0] as MainCategory);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [hovered, setHovered] = useState<string>('');
   const handleSetDebounce = useCallback(
-    (target: MainCategory, time: number) => {
+    (target: string, time: number) => {
       debounce(() => {
         setHovered(target);
       }, time);
     },
     [setHovered]
   );
+
   const handleHover = useCallback((e) => {
     const category = e.target.dataset.category;
     if (!category) return;
     handleSetDebounce(category, 100);
   }, []);
 
+  const fetchCategory = async () => {
+    const {
+      result: { categories },
+    } = await getAllCategory();
+    setCategories(categories);
+  };
+
+  useEffect(() => {
+    fetchCategory();
+  }, []);
+
+  const mainCategories = categories.map((category) => category.name);
+  const subCategories = categories.find((category) => category.name === hovered)?.categories?.map((c) => c.name);
+
   return (
     <CategoryContainer>
-      <MainCategoryList list={MAIN_CATEGORY} onHover={handleHover} hovered={hovered} />
-      <SubCategoryList list={SUB_CATEGORY} hovered={hovered} />
+      <MainCategoryList list={mainCategories} onHover={handleHover} hovered={hovered} />
+      {subCategories && <SubCategoryList list={subCategories} />}
     </CategoryContainer>
   );
 };

--- a/frontend/client/src/components/Header/HeaderBottom/Category/SubCategoryList/SubCategoryList.spec.tsx
+++ b/frontend/client/src/components/Header/HeaderBottom/Category/SubCategoryList/SubCategoryList.spec.tsx
@@ -6,23 +6,9 @@ import SubCategoryList from './SubCategoryList';
 
 describe('SubCategoryList Component', () => {
   it('should render "test1" "test2"', () => {
-    const wrapper = render(
-      <SubCategoryList list={{ 서브1: ['test1', 'test2'], 서브2: ['sub1', 'sub2'] }} hovered='서브1'></SubCategoryList>
-    );
+    const wrapper = render(<SubCategoryList list={['test1', 'test2']}></SubCategoryList>);
     expect(wrapper.getByText('test1')).toBeInTheDocument();
     expect(wrapper.getByText('test2')).toBeInTheDocument();
-  });
-
-  it('should render "문방구템"', () => {
-    const wrapper = render(<SubCategoryList list={{ 문구: ['문방구템'] }} hovered='문구'></SubCategoryList>);
-    expect(wrapper.getByText('문방구템')).toBeInTheDocument();
-  });
-
-  it('should render "연필"', () => {
-    const wrapper = render(
-      <SubCategoryList list={{ 상품: ['노트', '책가방', '연필'] }} hovered='상품'></SubCategoryList>
-    );
-    expect(wrapper.getByText('연필')).toBeInTheDocument();
   });
 
   afterAll(cleanup);

--- a/frontend/client/src/components/Header/HeaderBottom/Category/SubCategoryList/SubCategoryList.tsx
+++ b/frontend/client/src/components/Header/HeaderBottom/Category/SubCategoryList/SubCategoryList.tsx
@@ -4,14 +4,13 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface Props {
-  list: { [key: string]: string[] };
-  hovered: string;
+  list: string[];
 }
-const SubCategoryList: React.FC<Props> = ({ list, hovered }) => {
+const SubCategoryList: React.FC<Props> = ({ list }) => {
   return (
     <SubCategoryContainer>
       <SubCategories onMouseEnter={debounceClear}>
-        {list[hovered].map((category, i) => (
+        {list.map((category, i) => (
           <SubCategory key={i}>
             <SubCategoryLink to={`/category/${category}`}>
               <SubCategoryTitle>{category}</SubCategoryTitle>

--- a/frontend/client/src/types/Category.ts
+++ b/frontend/client/src/types/Category.ts
@@ -1,0 +1,5 @@
+export interface Category {
+  id: number;
+  name: string;
+  categories?: Category[];
+}


### PR DESCRIPTION
## :bookmark_tabs: 제목

카테고리 조회하는 API를 만들었습니다. 

> Repository는 DB에 있는 데이터를 돌려주는 용도로 역할을 최소화 시키는 게 좋을 듯합니다.

저는 service 계층에서 repository에서 받은 데이터를 이용해서 category 계층 구조로 데이터 변환작업을 진행했습니다. 다른 분들도 이렇게하는것이 어떨까 생각이 듭니다. repository는 typeorm 문법만 남겨두려고 노력해야할 듯합니다.

그리고 TypeORM `create`, `save` 와같은 API들을 정확히 알고 쓰는게 중요할듯합니다. 공식문서를 꼭 참조해주세요


 - 포스트맨으로 확인한 응답데이터 형태
 
<img width="352" alt="스크린샷 2021-08-16 오후 1 24 26" src="https://user-images.githubusercontent.com/20085849/129511354-d381e8ab-580e-4efe-bcd0-6a72df8a8ec6.png">

- Header 컴포넌트와 API 연동

![SmartLayer](https://user-images.githubusercontent.com/20085849/129513555-0a10f4d5-b7ba-457b-a098-5bde4215ad91.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] getAllCategory `GET /api/category`
- [x] createCategory `POST /api/category`
- [x] 예시 데이터 생성 (`database.ts`에 추가)
- [x] Header 컴포넌트와 API 연동. (HeaderBottom/Category 컴포넌트 수정)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- `database.ts` 여기에 초기 데이터를 넣어두는 작업을 추가하는데 너무 커지지않게 추후에 파일로 따로 분리하면 좋을듯하네요
