### PR TITLE
[feature/80] 찜하기 API 1/2 (클라이언트 미연동)

### DIFF
--- a/backend/src/controller/wish.controller.ts
+++ b/backend/src/controller/wish.controller.ts
@@ -2,14 +2,14 @@ import { Request, Response } from 'express';
 import WishService from '../service/wish.service';
 
 async function createWish(req: Request, res: Response) {
-  const userId = 1;
+  const userId = req.userId;
   const goodsId = req.body.goodsId;
   const result = await WishService.createWish(userId, goodsId);
   res.status(201).json({ result });
 }
 
 async function deleteWish(req: Request, res: Response) {
-  const userId = 1;
+  const userId = req.userId;
   const goodsId = Number(req.params.goodsId);
   await WishService.deleteWish(userId, goodsId);
   res.sendStatus(204);

--- a/backend/src/controller/wish.controller.ts
+++ b/backend/src/controller/wish.controller.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import WishService from '../service/wish.service';
+
+async function createWish(req: Request, res: Response) {
+  const userId = req.userId;
+  const goodsId = req.body.goodsId;
+  const result = await WishService.createWish(userId, goodsId);
+  res.status(201).json({ result });
+}
+
+async function deleteWish(req: Request, res: Response) {
+  const userId = req.userId;
+  const wishId = Number(req.params.wishId);
+  await WishService.deleteWish(userId, wishId);
+  res.sendStatus(204);
+}
+
+export default {
+  createWish,
+  deleteWish,
+};

--- a/backend/src/controller/wish.controller.ts
+++ b/backend/src/controller/wish.controller.ts
@@ -2,16 +2,16 @@ import { Request, Response } from 'express';
 import WishService from '../service/wish.service';
 
 async function createWish(req: Request, res: Response) {
-  const userId = req.userId;
+  const userId = 1;
   const goodsId = req.body.goodsId;
   const result = await WishService.createWish(userId, goodsId);
   res.status(201).json({ result });
 }
 
 async function deleteWish(req: Request, res: Response) {
-  const userId = req.userId;
-  const wishId = Number(req.params.wishId);
-  await WishService.deleteWish(userId, wishId);
+  const userId = 1;
+  const goodsId = Number(req.params.goodsId);
+  await WishService.deleteWish(userId, goodsId);
   res.sendStatus(204);
 }
 

--- a/backend/src/entity/Wish.ts
+++ b/backend/src/entity/Wish.ts
@@ -15,9 +15,6 @@ export class Wish {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id: number;
 
-  @Column({ type: 'int' })
-  amount: number;
-
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
 

--- a/backend/src/repository/wish.repository.ts
+++ b/backend/src/repository/wish.repository.ts
@@ -16,8 +16,7 @@ async function findWishByIds(userId: number, goodsId: number): Promise<Wish | un
 async function createWish(userId: number, goodsId: number): Promise<Wish> {
   try {
     const wishRepo = getRepository(Wish);
-  return await wishRepo.save({ userId, goodsId });
-    return wish;
+    return await wishRepo.save({ userId, goodsId });
   } catch (err) {
     console.error(err);
     throw new DatabaseError(WISH_DB_ERROR);

--- a/backend/src/repository/wish.repository.ts
+++ b/backend/src/repository/wish.repository.ts
@@ -6,7 +6,6 @@ import { DatabaseError } from '../errors/base.error';
 async function findWishByIds(userId: number, goodsId: number): Promise<Wish | undefined> {
   try {
     const wishRepo = getRepository(Wish);
-    const tmp = await wishRepo.findOne({ where: { userId, goodsId } });
     return await wishRepo.findOne({ where: { userId, goodsId } });
   } catch (err) {
     console.error(err);

--- a/backend/src/repository/wish.repository.ts
+++ b/backend/src/repository/wish.repository.ts
@@ -1,7 +1,38 @@
-import { getRepository } from 'typeorm';
-import { WISH_DB_ERROR } from '../constants/database-error-name';
+import { DeleteResult, getRepository } from 'typeorm';
+import { USER_ADDRESS_DB_ERROR, WISH_DB_ERROR } from '../constants/database-error-name';
 import { Wish } from '../entity/Wish';
 import { DatabaseError } from '../errors/base.error';
+
+async function findWishByIds(userId: number, wishId: number): Promise<Wish | undefined> {
+  try {
+    const wishRepo = getRepository(Wish);
+    return await wishRepo.findOne({ where: { id: wishId, user: userId } });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+  }
+}
+
+async function createWish(userId: number, goodsId: number): Promise<Wish> {
+  try {
+    const wishRepo = getRepository(Wish);
+    const wish = await wishRepo.save({ userId, goodsId });
+    return wish;
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+  }
+}
+
+async function deleteWish(wishId: number): Promise<DeleteResult> {
+  try {
+    const wishRepo = getRepository(Wish);
+    return await wishRepo.delete({ id: wishId });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+  }
+}
 
 async function findWishByUserId(userId: number): Promise<number[]> {
   try {
@@ -20,4 +51,7 @@ async function findWishByUserId(userId: number): Promise<number[]> {
 
 export const WishRepository = {
   findWishByUserId,
+  findWishByIds,
+  createWish,
+  deleteWish,
 };

--- a/backend/src/repository/wish.repository.ts
+++ b/backend/src/repository/wish.repository.ts
@@ -16,7 +16,7 @@ async function findWishByIds(userId: number, goodsId: number): Promise<Wish | un
 async function createWish(userId: number, goodsId: number): Promise<Wish> {
   try {
     const wishRepo = getRepository(Wish);
-    const wish = await wishRepo.save({ userId, goodsId });
+  return await wishRepo.save({ userId, goodsId });
     return wish;
   } catch (err) {
     console.error(err);

--- a/backend/src/repository/wish.repository.ts
+++ b/backend/src/repository/wish.repository.ts
@@ -1,15 +1,16 @@
 import { DeleteResult, getRepository } from 'typeorm';
-import { USER_ADDRESS_DB_ERROR, WISH_DB_ERROR } from '../constants/database-error-name';
+import { WISH_DB_ERROR } from '../constants/database-error-name';
 import { Wish } from '../entity/Wish';
 import { DatabaseError } from '../errors/base.error';
 
-async function findWishByIds(userId: number, wishId: number): Promise<Wish | undefined> {
+async function findWishByIds(userId: number, goodsId: number): Promise<Wish | undefined> {
   try {
     const wishRepo = getRepository(Wish);
-    return await wishRepo.findOne({ where: { id: wishId, user: userId } });
+    const tmp = await wishRepo.findOne({ where: { userId, goodsId } });
+    return await wishRepo.findOne({ where: { userId, goodsId } });
   } catch (err) {
     console.error(err);
-    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+    throw new DatabaseError(WISH_DB_ERROR);
   }
 }
 
@@ -20,17 +21,17 @@ async function createWish(userId: number, goodsId: number): Promise<Wish> {
     return wish;
   } catch (err) {
     console.error(err);
-    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+    throw new DatabaseError(WISH_DB_ERROR);
   }
 }
 
-async function deleteWish(wishId: number): Promise<DeleteResult> {
+async function deleteWish(userId: number, goodsId: number): Promise<DeleteResult> {
   try {
     const wishRepo = getRepository(Wish);
-    return await wishRepo.delete({ id: wishId });
+    return await wishRepo.delete({ userId, goodsId });
   } catch (err) {
     console.error(err);
-    throw new DatabaseError(USER_ADDRESS_DB_ERROR);
+    throw new DatabaseError(WISH_DB_ERROR);
   }
 }
 

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -4,6 +4,7 @@ import authRouter from './auth.router';
 import goodsRouter from './goods.router';
 import userRouter from './user.router';
 import categoryRouter from './category.router';
+import wishRouter from './wish.router';
 
 const router = express.Router();
 
@@ -11,4 +12,5 @@ router.use('/auth', authRouter);
 router.use('/goods', goodsRouter);
 router.use('/user', userRouter);
 router.use('/category', categoryRouter);
+router.use('/wish', wishRouter);
 export default router;

--- a/backend/src/router/wish.router.ts
+++ b/backend/src/router/wish.router.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import WishController from '../controller/wish.controller';
+import wrapAsync from '../utils/wrap-async';
+
+const router = express.Router();
+
+router.post('/goods', wrapAsync(WishController.createWish));
+router.delete('/goods/:wishId', wrapAsync(WishController.deleteWish));
+export default router;

--- a/backend/src/router/wish.router.ts
+++ b/backend/src/router/wish.router.ts
@@ -5,5 +5,5 @@ import wrapAsync from '../utils/wrap-async';
 const router = express.Router();
 
 router.post('/goods', wrapAsync(WishController.createWish));
-router.delete('/goods/:wishId', wrapAsync(WishController.deleteWish));
+router.delete('/goods/:goodsId', wrapAsync(WishController.deleteWish));
 export default router;

--- a/backend/src/service/wish.service.ts
+++ b/backend/src/service/wish.service.ts
@@ -15,8 +15,7 @@ async function deleteWish(userId: number, goodsId: number): Promise<DeleteResult
 
 async function isMineWish(userId: number, goodsId: number): Promise<boolean> {
   const wish = await WishRepository.findWishByIds(userId, goodsId);
-  if (wish) return true;
-  throw new NotFoundError(INVALID_ACCESS);
+  if (!wish) throw new NotFoundError(INVALID_ACCESS);
 }
 
 export default {

--- a/backend/src/service/wish.service.ts
+++ b/backend/src/service/wish.service.ts
@@ -1,0 +1,25 @@
+import { DeleteResult } from 'typeorm';
+import { INVALID_ACCESS } from '../constants/client-error-name';
+import { NotFoundError } from '../errors/client.error';
+import { WishRepository } from '../repository/wish.repository';
+import { CreateWishResponse } from '../types/response/wish.response';
+
+async function createWish(userId: number, goodsId: number): Promise<CreateWishResponse> {
+  return await WishRepository.createWish(userId, goodsId);
+}
+
+async function deleteWish(userId: number, wishId: number): Promise<DeleteResult> {
+  await isMineWish(userId, wishId);
+  return await WishRepository.deleteWish(wishId);
+}
+
+async function isMineWish(userId: number, wishId: number): Promise<boolean> {
+  const wish = await WishRepository.findWishByIds(userId, wishId);
+  if (wish) return true;
+  throw new NotFoundError(INVALID_ACCESS);
+}
+
+export default {
+  createWish,
+  deleteWish,
+};

--- a/backend/src/service/wish.service.ts
+++ b/backend/src/service/wish.service.ts
@@ -8,13 +8,13 @@ async function createWish(userId: number, goodsId: number): Promise<CreateWishRe
   return await WishRepository.createWish(userId, goodsId);
 }
 
-async function deleteWish(userId: number, wishId: number): Promise<DeleteResult> {
-  await isMineWish(userId, wishId);
-  return await WishRepository.deleteWish(wishId);
+async function deleteWish(userId: number, goodsId: number): Promise<DeleteResult> {
+  await isMineWish(userId, goodsId);
+  return await WishRepository.deleteWish(userId, goodsId);
 }
 
-async function isMineWish(userId: number, wishId: number): Promise<boolean> {
-  const wish = await WishRepository.findWishByIds(userId, wishId);
+async function isMineWish(userId: number, goodsId: number): Promise<boolean> {
+  const wish = await WishRepository.findWishByIds(userId, goodsId);
   if (wish) return true;
   throw new NotFoundError(INVALID_ACCESS);
 }

--- a/backend/src/types/response/wish.response.ts
+++ b/backend/src/types/response/wish.response.ts
@@ -1,0 +1,3 @@
+import { Wish } from '../../entity/Wish';
+
+export type CreateWishResponse = Wish;


### PR DESCRIPTION
## :bookmark_tabs: 제목

(작업 내역 한줄로 요약)

찜하기 등록

<img width="450" alt="스크린샷 2021-08-16 오후 6 12 32" src="https://user-images.githubusercontent.com/45394360/129540010-a094d64f-578a-4f99-bcbe-6cd325467890.png">

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 컨벤션을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] wish 등록
- [x] wish 삭제
- [x] wish 등록 관련 type 추가 (wish.response.ts)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Wish 삭제는 정상 처리시 별다른 데이터를 반환하지 않고 있습니다.  
초안에 없어서 그렇게 해뒀는데 이 부분에 대해서 내일 함께 얘기해보면 어떨까요? 😄 

- 클라이언트 연동과 함께 더미 데이터를 작업하려 합니다.  

- 상품 목록 연동 진행후 작업 재개 하도록 하겠습니다.