### PR TITLE
[feature/84] Promotion API 구현 및 클라이언트와 연동

### DIFF
--- a/backend/src/controller/payment.controller.ts
+++ b/backend/src/controller/payment.controller.ts
@@ -1,11 +1,13 @@
 import { Request, Response } from 'express';
 import { PaymentService } from '../service/payment.service';
+import { CreatePaymentRequest } from '../types/request/payment.request';
+
 async function getPayments(req: Request, res: Response) {
   const result = await PaymentService.getPayments();
   res.status(200).json({ result });
 }
 
-async function createPayment(req: Request, res: Response) {
+async function createPayment(req: CreatePaymentRequest, res: Response) {
   const body = req.body;
   const result = await PaymentService.createPayment(body);
   res.status(201).json({ result });

--- a/backend/src/controller/promotion.controller.ts
+++ b/backend/src/controller/promotion.controller.ts
@@ -1,4 +1,4 @@
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { PromotionService } from '../service/promotion.service';
 import { CreatePromotionRequest } from '../types/request/promotion.request';
 
@@ -8,6 +8,12 @@ async function createPromotion(req: CreatePromotionRequest, res: Response) {
   res.status(201).json({ result });
 }
 
+async function getPromotions(req: Request, res: Response) {
+  const result = await PromotionService.getPromotions();
+  res.status(200).json({ result });
+}
+
 export const PromotionController = {
   createPromotion,
+  getPromotions,
 };

--- a/backend/src/controller/promotion.controller.ts
+++ b/backend/src/controller/promotion.controller.ts
@@ -1,0 +1,13 @@
+import { Response } from 'express';
+import { PromotionService } from '../service/promotion.service';
+import { CreatePromotionRequest } from '../types/request/promotion.request';
+
+async function createPromotion(req: CreatePromotionRequest, res: Response) {
+  const body = req.body;
+  const result = await PromotionService.createPromotion(body);
+  res.status(201).json({ result });
+}
+
+export const PromotionController = {
+  createPromotion,
+};

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -15,6 +15,7 @@ import { Wish } from './entity/Wish';
 import { CategoryRepository } from './repository/category.repository';
 import { UserRepository } from './repository/user.repository';
 import { UserAddressRepository } from './repository/user.address.repository';
+import { PromotionRepository } from './repository/promotion.repository';
 
 export default async function () {
   await createConnection({
@@ -41,7 +42,18 @@ export default async function () {
 async function populate() {
   await createDefaultUser('아이유');
   await createDefaultAddress();
+  await createDefaultCategory();
+  await createDefaultPromotions();
+}
 
+async function createDefaultUser(name: string) {
+  const result = await UserRepository.findByGitHubId('1');
+  if (!result) {
+    await UserRepository.create('1', name);
+  }
+}
+
+async function createDefaultCategory() {
   const categories = [
     { name: 'A' },
     { parent: 'A', name: 'A1' },
@@ -53,13 +65,6 @@ async function populate() {
   ];
   for (const category of categories) {
     await createCategory(category.name, category.parent);
-  }
-}
-
-async function createDefaultUser(name: string) {
-  const result = await UserRepository.findByGitHubId('1');
-  if (!result) {
-    await UserRepository.create('1', name);
   }
 }
 
@@ -103,3 +108,20 @@ async function createDefaultAddress() {
 async function createDefaultOrderList() {}
 
 async function createDefaultPayment() {}
+
+async function createDefaultPromotions() {
+  const examplePromotionImgs = [
+    'https://user-images.githubusercontent.com/20085849/128992411-3b983b09-b0af-408a-bf56-4bde93c4b543.gif',
+    'https://user-images.githubusercontent.com/20085849/128992519-06368afd-3f31-459d-9050-101e730e304d.gif',
+    'https://user-images.githubusercontent.com/20085849/128992450-eb086cff-3b2a-4d4a-8b01-e3a8a8eaa754.gif',
+  ];
+  const promotion = await PromotionRepository.getPromotions();
+
+  for (const img of examplePromotionImgs) {
+    const exist = promotion.find((p) => p.imgUrl === img);
+    if (!exist) {
+      const newPromotion = await PromotionRepository.createPromotion(img);
+      console.log('프로모션 생성 :' + newPromotion.imgUrl);
+    }
+  }
+}

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -41,8 +41,19 @@ export default async function () {
 async function populate() {
   await createDefaultUser('아이유');
   await createDefaultAddress();
-  const categories = ['문구', '잡화', '생필품'];
-  categories.forEach((name) => createCategory(name));
+
+  const categories = [
+    { name: 'A' },
+    { parent: 'A', name: 'A1' },
+    { parent: 'A', name: 'A2' },
+    { parent: 'A', name: 'A3' },
+    { name: 'B' },
+    { parent: 'B', name: 'B1' },
+    { parent: 'B', name: 'B2' },
+  ];
+  for (const category of categories) {
+    await createCategory(category.name, category.parent);
+  }
 }
 
 async function createDefaultUser(name: string) {
@@ -52,10 +63,25 @@ async function createDefaultUser(name: string) {
   }
 }
 
-async function createCategory(name: string) {
-  const res = await CategoryRepository.getCategoryByName(name);
-  if (!res) {
-    await CategoryRepository.createCategory(name);
+async function createCategory(name: string, parentCategoryName?: string) {
+  if (parentCategoryName) {
+    const parent = await CategoryRepository.getCategoryByName(parentCategoryName);
+    if (!parent) {
+      throw Error(
+        '존재하지않는 부모 카테고리를 가진 데이터를 넣을 수 없습니다. parentCategory Name: ' + parentCategoryName
+      );
+    }
+    const originCategory = await CategoryRepository.getCategoryByName(name);
+    if (!originCategory) {
+      const newCategory = await CategoryRepository.createSubCategory(name, parent.id);
+      console.log(`초기 카테고리 데이터 삽입 : name - ${newCategory.name}, parent - ${parent.name}`);
+    }
+  } else {
+    const originCategory = await CategoryRepository.getCategoryByName(name);
+    if (!originCategory) {
+      const newCategory = await CategoryRepository.createCategory(name);
+      console.log(`초기 카테고리 데이터 삽입 : name - ${newCategory.name}`);
+    }
   }
 }
 

--- a/backend/src/entity/Promotion.ts
+++ b/backend/src/entity/Promotion.ts
@@ -15,7 +15,7 @@ export class Promotion {
   id: number;
 
   @Column({ type: 'varchar', length: 400 })
-  img_url: string;
+  imgUrl: string;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;

--- a/backend/src/repository/promotion.repository.ts
+++ b/backend/src/repository/promotion.repository.ts
@@ -1,0 +1,18 @@
+import { getRepository } from 'typeorm';
+import { PROMOTION_DB_ERROR } from '../constants/database-error-name';
+import { Promotion } from '../entity/Promotion';
+import { DatabaseError } from '../errors/base.error';
+
+async function createPromotion(imgUrl: string): Promise<Promotion> {
+  try {
+    const promotionRepo = getRepository(Promotion);
+    return await promotionRepo.save({ imgUrl });
+  } catch (err) {
+    console.log(err);
+    throw new DatabaseError(PROMOTION_DB_ERROR);
+  }
+}
+
+export const PromotionRepository = {
+  createPromotion,
+};

--- a/backend/src/repository/promotion.repository.ts
+++ b/backend/src/repository/promotion.repository.ts
@@ -6,7 +6,20 @@ import { DatabaseError } from '../errors/base.error';
 async function createPromotion(imgUrl: string): Promise<Promotion> {
   try {
     const promotionRepo = getRepository(Promotion);
-    return await promotionRepo.save({ imgUrl });
+    const newPromotionEntity = promotionRepo.create({
+      imgUrl,
+    });
+    return await promotionRepo.save(newPromotionEntity);
+  } catch (err) {
+    console.log(err);
+    throw new DatabaseError(PROMOTION_DB_ERROR);
+  }
+}
+
+async function getPromotions(): Promise<Promotion[]> {
+  try {
+    const promotionRepo = getRepository(Promotion);
+    return await promotionRepo.find();
   } catch (err) {
     console.log(err);
     throw new DatabaseError(PROMOTION_DB_ERROR);
@@ -15,4 +28,5 @@ async function createPromotion(imgUrl: string): Promise<Promotion> {
 
 export const PromotionRepository = {
   createPromotion,
+  getPromotions,
 };

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -8,6 +8,7 @@ import wishRouter from './wish.router';
 import orderRouter from './order.router';
 import paymentRouter from './payment.router';
 import searchRouter from './search.router';
+import promotionRouter from './promotion.router';
 
 const router = express.Router();
 
@@ -19,5 +20,6 @@ router.use('/wish', wishRouter);
 router.use('/order', orderRouter);
 router.use('/payment', paymentRouter);
 router.use('/search', searchRouter);
+router.use('/promotion', promotionRouter);
 
 export default router;

--- a/backend/src/router/promotion.router.ts
+++ b/backend/src/router/promotion.router.ts
@@ -5,5 +5,5 @@ import { PromotionController } from '../controller/promotion.controller';
 const router = express.Router();
 
 router.post('/', wrapAsync(PromotionController.createPromotion));
-
+router.get('/', wrapAsync(PromotionController.getPromotions));
 export default router;

--- a/backend/src/router/promotion.router.ts
+++ b/backend/src/router/promotion.router.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import wrapAsync from '../utils/wrap-async';
+import { PromotionController } from '../controller/promotion.controller';
+
+const router = express.Router();
+
+router.post('/', wrapAsync(PromotionController.createPromotion));
+
+export default router;

--- a/backend/src/service/promotion.service.ts
+++ b/backend/src/service/promotion.service.ts
@@ -1,0 +1,24 @@
+import { BadRequestError } from '../errors/client.error';
+import { PromotionRepository } from '../repository/promotion.repository';
+import { CreatePromotionBody } from '../types/request/promotion.request';
+import { PromotionResponse } from '../types/response/promotion.response';
+
+const PROMOTION_PARAMETER_ERROR = '프로모션을 등록하기위해서 imgUrl 값은 필수입니다.';
+
+async function createPromotion(body: CreatePromotionBody): Promise<PromotionResponse> {
+  const { imgUrl } = body;
+
+  if (!imgUrl) {
+    throw new BadRequestError(PROMOTION_PARAMETER_ERROR);
+  }
+
+  const newPromotion = await PromotionRepository.createPromotion(imgUrl);
+  return {
+    id: newPromotion.id,
+    imgUrl: newPromotion.imgUrl,
+  };
+}
+
+export const PromotionService = {
+  createPromotion,
+};

--- a/backend/src/service/promotion.service.ts
+++ b/backend/src/service/promotion.service.ts
@@ -19,6 +19,16 @@ async function createPromotion(body: CreatePromotionBody): Promise<PromotionResp
   };
 }
 
+async function getPromotions(): Promise<PromotionResponse[]> {
+  const promotions = await PromotionRepository.getPromotions();
+
+  return promotions.map((p) => ({
+    id: p.id,
+    imgUrl: p.imgUrl,
+  }));
+}
+
 export const PromotionService = {
   createPromotion,
+  getPromotions,
 };

--- a/backend/src/types/request/promotion.request.ts
+++ b/backend/src/types/request/promotion.request.ts
@@ -1,0 +1,8 @@
+import { Request } from 'express';
+export interface CreatePromotionBody {
+  imgUrl: string;
+}
+
+export interface CreatePromotionRequest extends Request {
+  body: CreatePromotionBody;
+}

--- a/backend/src/types/response/promotion.response.ts
+++ b/backend/src/types/response/promotion.response.ts
@@ -1,0 +1,4 @@
+export interface PromotionResponse {
+  id: number;
+  imgUrl: string;
+}

--- a/frontend/client/src/apis/promotionAPI.ts
+++ b/frontend/client/src/apis/promotionAPI.ts
@@ -1,0 +1,10 @@
+import { Promotion } from '@src/types/Promotion';
+import { APIResponse, checkedFetch } from './base';
+
+export const getPromotions = async (): Promise<APIResponse<Promotion[]>> => {
+  const res = await checkedFetch(`/api/promotion`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return await res.json();
+};

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { ThumbnailGoods } from '@src/types/Goods';
 import GoodsSection from '@src/components/GoodsSection/GoodsSection';
@@ -8,6 +8,7 @@ import Footer from '@src/components/Footer/Footer';
 import SideBar from './SideBar/SideBar';
 
 import { styled as CustomStyled } from '@src/lib/CustomStyledComponent';
+import { getPromotions } from '@src/apis/promotionAPI';
 
 const mockProductImagePath =
   'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg';
@@ -63,40 +64,34 @@ const mock_new_products: ThumbnailGoods[] = [
   { id: 8, thumbnailImg: mockProductImagePath, title: '맥쥬짠', price: 10000, isNew: true, discountRate: 0 },
 ];
 
-const mock_promotions: Promotion[] = [
-  {
-    id: 1,
-    imgUrl: 'https://user-images.githubusercontent.com/20085849/128992411-3b983b09-b0af-408a-bf56-4bde93c4b543.gif',
-    goodsId: 1,
-  },
-  {
-    id: 2,
-    imgUrl: 'https://user-images.githubusercontent.com/20085849/128992519-06368afd-3f31-459d-9050-101e730e304d.gif',
-    goodsId: 2,
-  },
-  {
-    id: 3,
-    imgUrl: 'https://user-images.githubusercontent.com/20085849/128992450-eb086cff-3b2a-4d4a-8b01-e3a8a8eaa754.gif',
-    goodsId: 3,
-  },
-];
+const Main = () => {
+  const [promotions, setPromotions] = useState<Promotion[]>([]);
+  const fetchPromotions = async () => {
+    const { result } = await getPromotions();
+    setPromotions(result);
+  };
 
-const Main = () => (
-  <>
-    <PromotionContainer>
-      <PromotionCarousel promotions={mock_promotions} />
-    </PromotionContainer>
-    <MainContentContainer>
-      <GoodsSection sectionTitle='잘나가요' goodsList={mock_best_products} itemBoxSize='big' />
-      <GoodsSection sectionTitle='새로 나왔어요' goodsList={mock_new_products} itemBoxSize='big' />
-      <GoodsSection sectionTitle='지금 할인 중' goodsList={mock_new_products} itemBoxSize='big' />
-    </MainContentContainer>
-    <SideBar goodsList={mock_best_products} />
-    <FooterContainer>
-      <Footer />
-    </FooterContainer>
-  </>
-);
+  useEffect(() => {
+    fetchPromotions();
+  }, []);
+
+  return (
+    <>
+      <PromotionContainer>
+        <PromotionCarousel promotions={promotions} />
+      </PromotionContainer>
+      <MainContentContainer>
+        <GoodsSection sectionTitle='잘나가요' goodsList={mock_best_products} itemBoxSize='big' />
+        <GoodsSection sectionTitle='새로 나왔어요' goodsList={mock_new_products} itemBoxSize='big' />
+        <GoodsSection sectionTitle='지금 할인 중' goodsList={mock_new_products} itemBoxSize='big' />
+      </MainContentContainer>
+      <SideBar goodsList={mock_best_products} />
+      <FooterContainer>
+        <Footer />
+      </FooterContainer>
+    </>
+  );
+};
 
 const PromotionContainer = styled.div`
   min-height: 300px;


### PR DESCRIPTION
## :bookmark_tabs: 제목

Promotion 관련 API 를 구현했습니다. (추가/조회) 

이미지 업로드관련해서는 기석님이 진행하시는 Goods 업로드 API가 완료되면 같이 반영해보겠습니다. 

그리고 클라이언트에 연동해놨습니다.

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] `GET /api/promotion`
- [x] `POST /api/promotion`
- [x] API 문서화하기
## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 프로모션 생성시 `goodsId`는 우선 안넣어놨습니다. 상품 API 등록이 완료됐을 시점에 넣겠습니다.
