### PR TITLE
[feature/103] Recoil을 사용해 주문/결제 페이지로 상품을 전달하기

### DIFF
--- a/frontend/client/src/hooks/usePushToOrderPage.ts
+++ b/frontend/client/src/hooks/usePushToOrderPage.ts
@@ -1,0 +1,28 @@
+import { usePushHistory } from '@src/lib/CustomRouter';
+import { orderState } from '@src/recoil/orderState';
+import { GoodsBeforeOrder } from '@src/types/Goods';
+import { useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+
+const usePushToOrderPage = () => {
+  const [orderGoodsList, setOrderState] = useRecoilState(orderState);
+  const pushHistory = usePushHistory();
+  const isInitialEffect = useRef(true);
+
+  const pushToOrderPage = (orderGoodsList: GoodsBeforeOrder[]) => {
+    setOrderState(orderGoodsList);
+  };
+
+  useEffect(() => {
+    if (isInitialEffect.current) {
+      isInitialEffect.current = false;
+      return;
+    }
+
+    pushHistory('/order');
+  }, [orderGoodsList]);
+
+  return pushToOrderPage;
+};
+
+export default usePushToOrderPage;

--- a/frontend/client/src/hooks/usePushToOrderPage.ts
+++ b/frontend/client/src/hooks/usePushToOrderPage.ts
@@ -1,26 +1,21 @@
+import { useRecoilState } from 'recoil';
+
 import { usePushHistory } from '@src/lib/CustomRouter';
 import { orderState } from '@src/recoil/orderState';
 import { GoodsBeforeOrder } from '@src/types/Goods';
-import { useEffect, useRef } from 'react';
-import { useRecoilState } from 'recoil';
 
 const usePushToOrderPage = () => {
-  const [orderGoodsList, setOrderState] = useRecoilState(orderState);
+  const [_, setOrderState] = useRecoilState(orderState);
   const pushHistory = usePushHistory();
-  const isInitialEffect = useRef(true);
 
-  const pushToOrderPage = (orderGoodsList: GoodsBeforeOrder[]) => {
+  async function setOrderGoodsList(orderGoodsList: GoodsBeforeOrder[]) {
     setOrderState(orderGoodsList);
-  };
+  }
 
-  useEffect(() => {
-    if (isInitialEffect.current) {
-      isInitialEffect.current = false;
-      return;
-    }
-
+  const pushToOrderPage = async (orderGoodsList: GoodsBeforeOrder[]) => {
+    await setOrderGoodsList(orderGoodsList);
     pushHistory('/order');
-  }, [orderGoodsList]);
+  };
 
   return pushToOrderPage;
 };

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -47,7 +47,8 @@ const CartPage: React.FC = () => {
   const handleChangeIsSelected = useCallback(
     (id: number, isSelected: boolean) => {
       const changedCartGoodsList = cartGoodsList.map((cartGoods) => {
-        return { ...cartGoods, isSelected: cartGoods.id === id };
+        if (cartGoods.id === id) return { ...cartGoods, isSelected };
+        return cartGoods;
       });
       setCartGoodsList(changedCartGoodsList);
     },
@@ -55,7 +56,8 @@ const CartPage: React.FC = () => {
   );
 
   const handleClickOrderButton = () => {
-    pushToOrderPage(cartGoodsList);
+    const filteredCartGoodsList = cartGoodsList.filter((cartGoods) => cartGoods.isSelected);
+    pushToOrderPage(filteredCartGoodsList);
   };
 
   useEffect(() => {

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -1,5 +1,6 @@
 import { deleteCarts, getCarts, updateCart } from '@src/apis/cartAPI';
 import PageHeader from '@src/components/PageHeader/PageHeader';
+import usePushToOrderPage from '@src/hooks/usePushToOrderPage';
 import { usePushHistory } from '@src/lib/CustomRouter';
 import { CartGoods } from '@src/types/Goods';
 import React, { useCallback, useState } from 'react';
@@ -10,7 +11,7 @@ import EmptyCart from './EmptyCart/EmptyCart';
 import Layout from './Layout/Layout';
 
 const CartPage: React.FC = () => {
-  const pushHistory = usePushHistory();
+  const pushToOrderPage = usePushToOrderPage();
   const [cartGoodsList, setCartGoodsList] = useState<CartGoods[]>([]);
   const [isCartsFetched, setIsCartsFetched] = useState(false);
 
@@ -46,16 +47,15 @@ const CartPage: React.FC = () => {
   const handleChangeIsSelected = useCallback(
     (id: number, isSelected: boolean) => {
       const changedCartGoodsList = cartGoodsList.map((cartGoods) => {
-   return { ...cartGoods, isSelected : cartGoods.id === id };
+        return { ...cartGoods, isSelected: cartGoods.id === id };
       });
       setCartGoodsList(changedCartGoodsList);
     },
     [cartGoodsList, setCartGoodsList]
   );
 
-  // TODO: 상품을 주문/결제 페이지에 전달하기
   const handleClickOrderButton = () => {
-    pushHistory('/order');
+    pushToOrderPage(cartGoodsList);
   };
 
   useEffect(() => {

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
@@ -10,15 +10,18 @@ interface Props {
   onToggleWish: () => void;
   addToCart: () => void;
   fetchCheckStock: (goodsId: number) => Promise<void>;
+  onOrder: () => void;
 }
 
-const GoodsButtons: React.FC<Props> = ({ goodsId, amount, isWish, fetchCheckStock, onToggleWish, addToCart }) => {
-  const onOrder = useCallback(async () => {
-    await fetchCheckStock(goodsId);
-    // 페이지 이동 처리
-    // TODO: 어진님이 이미 작업하셔서 패스했습니다! 감사합니다!! :)
-  }, [amount]);
-
+const GoodsButtons: React.FC<Props> = ({
+  goodsId,
+  amount,
+  isWish,
+  fetchCheckStock,
+  onToggleWish,
+  addToCart,
+  onOrder,
+}) => {
   return (
     <>
       <GoodsButtonsContainer>

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -1,18 +1,20 @@
 import GoodsButtons from './GoodsButtons/GoodsButtons';
 import GoodsAmount from './GoodsAmount/GoodsAmount';
-import { DetailGoods } from '@src/types/Goods';
+import { DetailGoods, GoodsBeforeOrder } from '@src/types/Goods';
 import React, { useState, useCallback, useEffect } from 'react';
 import { deleteWish, postWish } from '@src/apis/wishAPI';
 import { getGoodsStockCount } from '@src/apis/goodsAPI';
 import { createCart } from '@src/apis/cartAPI';
+import usePushToOrderPage from '@src/hooks/usePushToOrderPage';
 
 interface Props {
   goods: DetailGoods;
 }
 
-const GoodsInteractive: React.FC<Props> = ({
-  goods: { id, title, price, deliveryFee = 0, discountRate = 0, isWish = false },
-}) => {
+const GoodsInteractive: React.FC<Props> = ({ goods }) => {
+  const { id, title, price, deliveryFee = 0, discountRate = 0, isWish = false } = goods;
+  const pushToOrderPage = usePushToOrderPage();
+
   const [isWished, setIsWished] = useState(isWish);
   const [isOver, setIsOver] = useState(false);
   const [amount, setAmount] = useState(0);
@@ -21,6 +23,16 @@ const GoodsInteractive: React.FC<Props> = ({
     const result = await (isWished ? deleteWish(id) : postWish(id));
     if (result) setIsWished(!isWished);
   }, [isWished]);
+
+  // const handleToWish = useCallback(async () => {}, []);
+  const handleAddToCart = useCallback(() => {
+    console.log('장바구니 추가 API', 'goods id:', id);
+  }, []);
+
+  const handleAddToOrder = () => {
+    const orderGoods: GoodsBeforeOrder = { goods, amount };
+    pushToOrderPage([orderGoods]);
+  };
 
   const addToCart = useCallback(async () => {
     console.log('장바구니 추가 API', 'goods id:', id);

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -72,6 +72,7 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
         setAmount={setAmount}
       />
       <GoodsButtons
+        onOrder={handleAddToOrder}
         isWish={isWished}
         amount={amount}
         goodsId={id}

--- a/frontend/client/src/pages/Order/OrderGoodsList/OrderGoodsList.tsx
+++ b/frontend/client/src/pages/Order/OrderGoodsList/OrderGoodsList.tsx
@@ -1,16 +1,16 @@
-import { OrderGoods } from '@src/types/Goods';
+import { GoodsBeforeOrder } from '@src/types/Goods';
 import React from 'react';
 import OrderGoodsListItem from './OrderGoodsListItem/OrderGoodsListItem';
 
 interface Props {
-  orderGoodsList: OrderGoods[];
+  orderGoodsList: GoodsBeforeOrder[];
 }
 
 const OrderGoodsList: React.FC<Props> = ({ orderGoodsList }) => {
   return (
     <>
       {orderGoodsList.map((orderGoods) => (
-        <OrderGoodsListItem key={orderGoods.id} orderGoods={orderGoods} />
+        <OrderGoodsListItem key={orderGoods.goods.id} orderGoods={orderGoods} />
       ))}
     </>
   );

--- a/frontend/client/src/pages/Order/OrderGoodsList/OrderGoodsListItem/OrderGoodsListItem.tsx
+++ b/frontend/client/src/pages/Order/OrderGoodsList/OrderGoodsListItem/OrderGoodsListItem.tsx
@@ -1,14 +1,15 @@
-import { OrderGoods } from '@src/types/Goods';
+import { GoodsBeforeOrder } from '@src/types/Goods';
 import { getDiscountedPrice, getPriceText } from '@src/utils/price';
 import React from 'react';
 import styled from 'styled-components';
 
 interface Props {
-  orderGoods: OrderGoods;
+  orderGoods: GoodsBeforeOrder;
 }
 
 const OrderGoodsListItem: React.FC<Props> = ({ orderGoods }) => {
-  const { id, thumbnailUrl, title, price, discountRate, amount } = orderGoods;
+  const { goods, amount } = orderGoods;
+  const { id, thumbnailUrl, title, price, discountRate } = goods;
 
   return (
     <Wrapper>

--- a/frontend/client/src/pages/Order/OrderPage.tsx
+++ b/frontend/client/src/pages/Order/OrderPage.tsx
@@ -1,21 +1,46 @@
-import React from 'react';
-import { useState } from 'react';
+import styled from 'styled-components';
+import React, { useMemo, useState } from 'react';
+
+import { useRecoilValue } from 'recoil';
+import { orderState } from '@src/recoil/orderState';
+
 import PageHeader from '@src/components/PageHeader/PageHeader';
 import Layout from '@src/pages/Cart/Layout/Layout';
-import styled from 'styled-components';
 import Divider from '@src/components/Divider/Divider';
 import Button from '@src/components/PrimaryButton/PrimaryButton';
 import CheckButtonWithLabel from '@src/components/CheckButtonWithLabel/CheckButtonWithLabel';
 import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import Topic from '@src/components/Topic/Topic';
-import { GoodsBeforeOrder } from '@src/types/Goods';
+import { AddressInfo } from '@src/types/Address';
+import { getDiscountedPrice, getPriceText } from '@src/utils/price';
 import OrderGoodsList from './OrderGoodsList/OrderGoodsList';
 import AddressSection from './AddressSection/AddressSection';
+import { usePushHistory } from '@src/lib/CustomRouter';
 
-const mock: GoodsBeforeOrder[] = [];
-
+// TODO: NoData, Payment fetching, 체크박스 및 배송지 벨리데이션 후 Alert
 const OrderPage: React.FC = () => {
-  const [orderGoodsList, setOrderGoodsList] = useState<GoodsBeforeOrder[]>(mock);
+  const orderGoodsList = useRecoilValue(orderState);
+  const [selectedAddress, setSelectedAddress] = useState<AddressInfo | null>(null);
+  const pushHistory = usePushHistory();
+
+  const reducedPrice = useMemo(
+    () =>
+      orderGoodsList.reduce(
+        (prev, cartGoods) =>
+          prev + cartGoods.amount * getDiscountedPrice(cartGoods.goods.price, cartGoods.goods.discountRate),
+        0
+      ),
+    [orderGoodsList]
+  );
+  // TODO: 배송비 정책 결정하고 대응 수정하기
+  // 임시적으로 30000원 이상이면 배송비 0원, 아니면 2500원 부여
+  const deliveryPrice = orderGoodsList.length !== 0 && reducedPrice < 30000 ? 2500 : 0;
+  const totalPrice = reducedPrice + deliveryPrice;
+
+  if (orderGoodsList.length === 0) {
+    pushHistory('/');
+    return null;
+  }
 
   return (
     <Layout
@@ -24,10 +49,10 @@ const OrderPage: React.FC = () => {
         <FlexColumn gap='4rem'>
           <div>
             <Topic>배송정보</Topic>
-            <AddressSection />
+            <AddressSection onChangeSelectedAddress={setSelectedAddress} />
           </div>
           <div>
-            <Topic>주문 상품 (1건)</Topic>
+            <Topic>주문 상품 ({orderGoodsList.length}건)</Topic>
             <OrderGoodsList orderGoodsList={orderGoodsList} />
           </div>
         </FlexColumn>
@@ -39,16 +64,16 @@ const OrderPage: React.FC = () => {
               <Topic>결제금액</Topic>
               <FlexRowSpaceBetween>
                 <div>상품금액</div>
-                <div>42,800원</div>
+                <div>{getPriceText(reducedPrice)}원</div>
               </FlexRowSpaceBetween>
               <FlexRowSpaceBetween>
                 <div>배송비</div>
-                <div>+0원</div>
+                <div>+{getPriceText(deliveryPrice)}원</div>
               </FlexRowSpaceBetween>
               <Divider lineStyle='dashed' />
               <FlexRowSpaceBetween>
                 <HighlightedText>총 결제금액</HighlightedText>
-                <HighlightedText>42,800원</HighlightedText>
+                <HighlightedText>{getPriceText(totalPrice)}원</HighlightedText>
               </FlexRowSpaceBetween>
             </FlexColumn>
           </PaddingBox>
@@ -65,7 +90,7 @@ const OrderPage: React.FC = () => {
           <PaddingBox>
             <FlexColumn gap='1rem'>
               <CheckButtonWithLabel isChecked={true} onClick={() => {}} label='결제 진행에 필요한 사항 동의' />
-              <Button fullWidth>42,800원 결제하기</Button>
+              <Button fullWidth>{getPriceText(totalPrice)}원 결제하기</Button>
             </FlexColumn>
           </PaddingBox>
         </BorderBox>

--- a/frontend/client/src/pages/Order/OrderPage.tsx
+++ b/frontend/client/src/pages/Order/OrderPage.tsx
@@ -8,35 +8,14 @@ import Button from '@src/components/PrimaryButton/PrimaryButton';
 import CheckButtonWithLabel from '@src/components/CheckButtonWithLabel/CheckButtonWithLabel';
 import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import Topic from '@src/components/Topic/Topic';
-import { OrderGoods } from '@src/types/Goods';
+import { GoodsBeforeOrder } from '@src/types/Goods';
 import OrderGoodsList from './OrderGoodsList/OrderGoodsList';
 import AddressSection from './AddressSection/AddressSection';
 
-const mock: OrderGoods[] = [
-  {
-    id: 1,
-    thumbnailUrl:
-      'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-    title: '든든 오뚜기 오쉐프_마요네즈',
-    price: 34500,
-    discountRate: 20,
-    amount: 2,
-    stock: 5,
-  },
-  {
-    id: 2,
-    thumbnailUrl:
-      'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-    title: '허약 마요네즈',
-    price: 9000,
-    discountRate: 0,
-    amount: 1,
-    stock: 8,
-  },
-];
+const mock: GoodsBeforeOrder[] = [];
 
 const OrderPage: React.FC = () => {
-  const [orderGoodsList, setOrderGoodsList] = useState<OrderGoods[]>(mock);
+  const [orderGoodsList, setOrderGoodsList] = useState<GoodsBeforeOrder[]>(mock);
 
   return (
     <Layout

--- a/frontend/client/src/recoil/orderState.ts
+++ b/frontend/client/src/recoil/orderState.ts
@@ -1,0 +1,7 @@
+import { GoodsBeforeOrder } from '@src/types/Goods';
+import { atom } from 'recoil';
+
+export const orderState = atom<GoodsBeforeOrder[]>({
+  key: 'orderState',
+  default: [],
+});

--- a/frontend/client/src/types/Goods.ts
+++ b/frontend/client/src/types/Goods.ts
@@ -41,3 +41,14 @@ export type MainGoodsListResult = {
   latestGoodsList: ThumbnailGoods[];
   discountGoodsList: ThumbnailGoods[];
 };
+
+// TODO: 이름 바꿀 필요가 있음. GoodsPaginationResult
+export interface GoodsPaginationResult {
+  goodsList: ThumbnailGoods[];
+  meta: {
+    page: number;
+    limit: number;
+    totalPage: number;
+    totalCount: number;
+  };
+}

--- a/frontend/client/src/types/Goods.ts
+++ b/frontend/client/src/types/Goods.ts
@@ -24,33 +24,20 @@ export type DetailGoods = Goods & {
   goodsImgs?: string[];
 };
 
-export type CartGoods = {
+export interface CartGoods {
   id: number;
   amount: number;
-  isSelected: boolean;
   goods: Goods;
-};
+  isSelected: boolean;
+}
+
+export interface GoodsBeforeOrder {
+  amount: number;
+  goods: Goods;
+}
 
 export type MainGoodsListResult = {
   bestGoodsList: ThumbnailGoods[];
   latestGoodsList: ThumbnailGoods[];
   discountGoodsList: ThumbnailGoods[];
 };
-
-export type OrderGoods = Goods & {
-  thumbnailUrl: string;
-  discountRate: number;
-  amount: number;
-  stock: number;
-};
-
-// TODO: 이름 바꿀 필요가 있음. GoodsPaginationResult
-export interface GoodsPaginationResult {
-  goodsList: ThumbnailGoods[];
-  meta: {
-    page: number;
-    limit: number;
-    totalPage: number;
-    totalCount: number;
-  };
-}


### PR DESCRIPTION
## :bookmark_tabs: 제목

https://user-images.githubusercontent.com/64543699/129866130-33e75132-626c-41d6-9741-8d92a84b84be.mov

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Recoil을 사용해 주문/결제 페이지로 상품을 전달하기
- [x] 주문/결제 페이지 동작 개선

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 상품 디테일 페이지 내부 컴포넌트의 코드가 일부 수정되었습니다. (@kowoohyuk )
- 훅을 사용해서 주문/결제 페이지로 상품을 전달하며 이동하도록 구현하였습니다.
