### PR TITLE
fix: uploads 폴더 생성 권한 허용하도록 code agent permission 변경

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -7,7 +7,7 @@ files:
 permissions:
   - object: /home/ubuntu/
     pattern: '**'
-    mode: 755
+    mode: 777
     owner: ubuntu
     group: ubuntu
 hooks:

--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -5,7 +5,7 @@ HOME=/home/ubuntu
 SERVER_APP_REPOSITORY=/home/ubuntu/store-5/backend
 
 cd $SERVER_APP_REPOSITORY
-pm2 start ./dist/bundle.js
+pm2 start ./dist/bundle.js > $HOME/deploy_after.txt
 
 rm -r $HOME/touch_CICD.txt
 

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -3,7 +3,7 @@
 HOME=/home/ubuntu
 cd $HOME
 
-pm2 delete all
+pm2 delete all > $HOME/deploy_before.txt
 rm -rf store-5
 
 touch $HOME/touch_CICD.txt


### PR DESCRIPTION
## :bookmark_tabs: 제목

히스토리 : admin app 을 배포하던 중 임시로 image 업로드 기능을 테스트하기 위해 backend uploads 폴더를 express multer가 추가해주도록 하는 기능을 추가했습니다.  그런데 배포 스크립트를 실행하는 권한때문에 해당 폴더를 생성할 수 없는 상황

해결 : 배포시 권한 수정 