### PR TITLE
fix: 배포 스크립트 pm2 못찾는 에러 해결

### DIFF
--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+source /home/ubuntu/.bashrc
+
 HOME=/home/ubuntu
 
 SERVER_APP_REPOSITORY=/home/ubuntu/store-5/backend
 
 cd $SERVER_APP_REPOSITORY
+
 pm2 start ./dist/bundle.js > $HOME/deploy_after.txt
 
 rm -r $HOME/touch_CICD.txt

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+source /home/ubuntu/.bashrc
+
 HOME=/home/ubuntu
+
 cd $HOME
 
 pm2 delete all > $HOME/deploy_before.txt
+
 rm -rf store-5
 
 touch $HOME/touch_CICD.txt


### PR DESCRIPTION
## :bookmark_tabs: 제목

Code Deploy 를 이용해서 배포할 경우, PM2가 계속 실행되지않는 현상이 있어서 확인해보니 npm의 경로를 결정하는 코드가 .bashrc에 있어서 그랬습니다. 스크립트를 수정했습니다.