### PR TITLE
[feature/94] 상품 상세 및 상품 컴포넌트 API 연동

### DIFF
--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -36,16 +36,19 @@ async function createGoods(req: CreateGoodsRequest, res: Response) {
   res.status(201).json({ result });
 }
 
-// TODO: 테스트 문의
+// TODO: getDetailById에 undefined가 아니라 number | null로 하는게 나을까요?
 async function getGoodsDetail(req: Request, res: Response) {
   const goodsId = Number(req.params.id);
-  const userId = req.userId;
+  let userId;
+  if (req.userId > -1) userId = req.userId;
   const result = await GoodsService.getDetailById(goodsId, userId);
   res.status(200).json({ result });
 }
 
 async function getAllGoodsCategory(req: Request, res: Response) {
   const { page, category, flag = GoodsFlag.latest, limit, state = GoodsStateMap.sale } = req.query;
+  let userId;
+  if (req.userId > -1) userId = req.userId;
   // TODO : 타입 체크
   const GoodsListParams: GetAllByCategoryProps = {
     categoryName: String(category),
@@ -53,7 +56,7 @@ async function getAllGoodsCategory(req: Request, res: Response) {
     flag: String(flag) as GoodsFlag,
     limit: Number(limit),
     state: String(state) as GoodsState,
-    userId: req.userId,
+    userId,
   };
 
   const result = await GoodsService.getAllSaleGoodsByCategory(GoodsListParams);
@@ -62,28 +65,15 @@ async function getAllGoodsCategory(req: Request, res: Response) {
 
 async function getAllSaleGoodsByKeyword(req: Request, res: Response) {
   const { page, keyword, limit, state = GoodsStateMap.sale } = req.query;
+  let userId;
+  if (req.userId > -1) userId = req.userId;
   // TODO : 타입 체크
   const GoodsListParams: GetAllByKeywordProps = {
     keyword: String(keyword),
     page: Number(page),
     limit: Number(limit),
     state: String(state) as GoodsState,
-    userId: req.userId,
-  };
-
-  const result = await GoodsService.getAllSaleGoodsByKeyword(GoodsListParams);
-  return res.status(200).json({ result });
-}
-
-async function getAllGoodsByUserId(req: Request, res: Response) {
-  const { page, keyword, limit, state = GoodsStateMap.sale } = req.query;
-  // TODO : 타입 체크
-  const GoodsListParams: GetAllByKeywordProps = {
-    keyword: String(keyword),
-    page: Number(page),
-    limit: Number(limit),
-    state: String(state) as GoodsState,
-    userId: req.userId,
+    userId,
   };
 
   const result = await GoodsService.getAllSaleGoodsByKeyword(GoodsListParams);
@@ -91,7 +81,9 @@ async function getAllGoodsByUserId(req: Request, res: Response) {
 }
 
 async function getMainGoodsListMap(req: Request, res: Response) {
-  const result = await GoodsService.getMainGoodsListMap();
+  let userId;
+  if (req.userId > -1) userId = req.userId;
+  const result = await GoodsService.getMainGoodsListMap(userId);
   return res.status(200).json({ result });
 }
 

--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -36,19 +36,16 @@ async function createGoods(req: CreateGoodsRequest, res: Response) {
   res.status(201).json({ result });
 }
 
-// TODO: getDetailById에 undefined가 아니라 number | null로 하는게 나을까요?
 async function getGoodsDetail(req: Request, res: Response) {
   const goodsId = Number(req.params.id);
-  let userId;
-  if (req.userId > -1) userId = req.userId;
+  const userId = req.session.userId;
   const result = await GoodsService.getDetailById(goodsId, userId);
   res.status(200).json({ result });
 }
 
 async function getAllGoodsCategory(req: Request, res: Response) {
   const { page, category, flag = GoodsFlag.latest, limit, state = GoodsStateMap.sale } = req.query;
-  let userId;
-  if (req.userId > -1) userId = req.userId;
+  const userId = req.session.userId;
   // TODO : 타입 체크
   const GoodsListParams: GetAllByCategoryProps = {
     categoryName: String(category),
@@ -65,8 +62,7 @@ async function getAllGoodsCategory(req: Request, res: Response) {
 
 async function getAllSaleGoodsByKeyword(req: Request, res: Response) {
   const { page, keyword, limit, state = GoodsStateMap.sale } = req.query;
-  let userId;
-  if (req.userId > -1) userId = req.userId;
+  const userId = req.session.userId;
   // TODO : 타입 체크
   const GoodsListParams: GetAllByKeywordProps = {
     keyword: String(keyword),
@@ -81,8 +77,7 @@ async function getAllSaleGoodsByKeyword(req: Request, res: Response) {
 }
 
 async function getMainGoodsListMap(req: Request, res: Response) {
-  let userId;
-  if (req.userId > -1) userId = req.userId;
+  const userId = req.session.userId;
   const result = await GoodsService.getMainGoodsListMap(userId);
   return res.status(200).json({ result });
 }

--- a/backend/src/middlewares/set-authenticate.middleware.ts
+++ b/backend/src/middlewares/set-authenticate.middleware.ts
@@ -1,0 +1,9 @@
+import { Response, NextFunction, Request } from 'express';
+
+const GUEST = -1;
+
+export default function setAuthenticate(req: Request, res: Response, next: NextFunction) {
+  const { userId } = req.session;
+  req.userId = userId ?? GUEST;
+  next();
+}

--- a/backend/src/middlewares/set-authenticate.middleware.ts
+++ b/backend/src/middlewares/set-authenticate.middleware.ts
@@ -1,9 +1,0 @@
-import { Response, NextFunction, Request } from 'express';
-
-const GUEST = -1;
-
-export default function setAuthenticate(req: Request, res: Response, next: NextFunction) {
-  const { userId } = req.session;
-  req.userId = userId ?? GUEST;
-  next();
-}

--- a/backend/src/router/goods.router.ts
+++ b/backend/src/router/goods.router.ts
@@ -3,6 +3,7 @@ import { MAX_UPLOAD_FILE } from '../constants/product-default-value';
 import { GoodsController } from '../controller/goods.controller';
 import checkNumberInParams from '../middlewares/check-number-params';
 import isAuthenticate from '../middlewares/is-authenticate';
+import setAuthenticate from '../middlewares/set-authenticate.middleware';
 import uploadProductFiles from '../middlewares/upload-file';
 import wrapAsync from '../utils/wrap-async';
 
@@ -14,9 +15,9 @@ router.post(
   uploadProductFiles.array('files', MAX_UPLOAD_FILE),
   wrapAsync(GoodsController.createGoods)
 );
-router.get('/category', wrapAsync(GoodsController.getAllGoodsCategory));
-router.get('/keyword', wrapAsync(GoodsController.getAllSaleGoodsByKeyword));
-router.get('/main', wrapAsync(GoodsController.getMainGoodsListMap));
+router.get('/category', setAuthenticate, wrapAsync(GoodsController.getAllGoodsCategory));
+router.get('/keyword', setAuthenticate, wrapAsync(GoodsController.getAllSaleGoodsByKeyword));
+router.get('/main', setAuthenticate, wrapAsync(GoodsController.getMainGoodsListMap));
 router.get('/:id/stock', checkNumberInParams, wrapAsync(GoodsController.getGoodsStockById));
-router.get('/:id', checkNumberInParams, wrapAsync(GoodsController.getGoodsDetail));
+router.get('/:id', setAuthenticate, checkNumberInParams, wrapAsync(GoodsController.getGoodsDetail));
 export default router;

--- a/backend/src/router/goods.router.ts
+++ b/backend/src/router/goods.router.ts
@@ -2,8 +2,6 @@ import express from 'express';
 import { MAX_UPLOAD_FILE } from '../constants/product-default-value';
 import { GoodsController } from '../controller/goods.controller';
 import checkNumberInParams from '../middlewares/check-number-params';
-import isAuthenticate from '../middlewares/is-authenticate';
-import setAuthenticate from '../middlewares/set-authenticate.middleware';
 import uploadProductFiles from '../middlewares/upload-file';
 import wrapAsync from '../utils/wrap-async';
 
@@ -15,9 +13,9 @@ router.post(
   uploadProductFiles.array('files', MAX_UPLOAD_FILE),
   wrapAsync(GoodsController.createGoods)
 );
-router.get('/category', setAuthenticate, wrapAsync(GoodsController.getAllGoodsCategory));
-router.get('/keyword', setAuthenticate, wrapAsync(GoodsController.getAllSaleGoodsByKeyword));
-router.get('/main', setAuthenticate, wrapAsync(GoodsController.getMainGoodsListMap));
+router.get('/category', wrapAsync(GoodsController.getAllGoodsCategory));
+router.get('/keyword', wrapAsync(GoodsController.getAllSaleGoodsByKeyword));
+router.get('/main', wrapAsync(GoodsController.getMainGoodsListMap));
 router.get('/:id/stock', checkNumberInParams, wrapAsync(GoodsController.getGoodsStockById));
-router.get('/:id', setAuthenticate, checkNumberInParams, wrapAsync(GoodsController.getGoodsDetail));
+router.get('/:id', checkNumberInParams, wrapAsync(GoodsController.getGoodsDetail));
 export default router;

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -1,5 +1,5 @@
 import { GoodsImg } from './../entity/GoodsImg';
-import { ColumnTypeUndefinedError, getConnection, MoreThan } from 'typeorm';
+import { getConnection, MoreThan } from 'typeorm';
 import { Goods } from '../entity/Goods';
 import { GoodsRepository } from '../repository/goods.repository';
 import {
@@ -137,7 +137,7 @@ async function getAllGoodsByUserId({ page, limit, userId }: GetAllByUserIdProps)
 }
 
 // TODO: 각 조회를 하나의 함수로 분리?
-async function getMainGoodsListMap(): Promise<{
+async function getMainGoodsListMap(userId?: number): Promise<{
   bestGoodsList: TaggedGoodsType[];
   latestGoodsList: TaggedGoodsType[];
   discountGoodsList: TaggedGoodsType[];
@@ -158,6 +158,14 @@ async function getMainGoodsListMap(): Promise<{
   const bestGoodsList = await GoodsRepository.findAllByColumnName(bestProps);
   const latestGoodsList = await GoodsRepository.findAllByColumnName(latestProps);
   const discountGoodsList = await GoodsRepository.findAllByColumnName(discountProps);
+  if (userId) {
+    const wishSet = new Set(await WishRepository.findWishByUserId(userId));
+    if (wishSet) {
+      bestGoodsList.forEach((goods) => (goods.isWish = wishSet.has(goods.id)));
+      latestGoodsList.forEach((goods) => (goods.isWish = wishSet.has(goods.id)));
+      discountGoodsList.forEach((goods) => (goods.isWish = wishSet.has(goods.id)));
+    }
+  }
   return {
     bestGoodsList,
     latestGoodsList,

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -1,11 +1,10 @@
 import { usePushHistory } from '@src/lib/CustomRouter/CustomRouter';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { BsHeart, BsFillBucketFill, BsFillHeartFill } from 'react-icons/bs';
 import { BestTag, GreenTag, NewTag, SaleTag } from '../Tag';
-import { useCallback } from 'react';
-import { useState } from 'react';
 import { getPriceText } from '@src/utils/price';
+import { deleteWish, postWish } from '@src/apis/wishAPI';
 
 export type GoodsItemSize = 'small' | 'middle' | 'big';
 
@@ -39,6 +38,7 @@ const GoodsItem: React.FC<Props> = ({
   handleClickCart,
 }) => {
   const push = usePushHistory();
+  const [isWished, setIsWished] = useState(isWish);
   const handleClickGoodsItem = (e: React.MouseEvent) => {
     push('/detail/' + id);
   };
@@ -54,9 +54,21 @@ const GoodsItem: React.FC<Props> = ({
 
   const handleClickUtliButton = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    e.preventDefault;
     handleClickCart && handleClickCart(id);
   }, []);
+
+  const handleToWish = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      try {
+        const result = await (isWished ? deleteWish(id) : postWish(id));
+        if (result) setIsWished(!isWished);
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [isWished]
+  );
   return (
     <GoodsItemContainer onClick={handleClickGoodsItem} size={itemBoxSize}>
       <GoodsImageContainer onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave} size={itemBoxSize}>
@@ -71,7 +83,9 @@ const GoodsItem: React.FC<Props> = ({
         {isHoverGoodsImage && <></>}
         <GoodsImageOverlay />
         <GoodsUtilBtnContainer>
-          <GoodsUtilBtn>{isWish ? <BsFillHeartFill size={20} /> : <BsHeart size={20} />}</GoodsUtilBtn>
+          <GoodsUtilBtn onClick={handleToWish}>
+            {isWished ? <BsFillHeartFill size={20} /> : <BsHeart size={20} />}
+          </GoodsUtilBtn>
           <GoodsUtilBtn onClick={handleClickUtliButton}>
             <BsFillBucketFill size={20} />
           </GoodsUtilBtn>

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -5,6 +5,7 @@ import { BsHeart, BsFillBucketFill, BsFillHeartFill } from 'react-icons/bs';
 import { BestTag, GreenTag, NewTag, SaleTag } from '../Tag';
 import { getPriceText } from '@src/utils/price';
 import { deleteWish, postWish } from '@src/apis/wishAPI';
+import theme from '@src/theme/theme';
 
 export type GoodsItemSize = 'small' | 'middle' | 'big';
 
@@ -84,7 +85,7 @@ const GoodsItem: React.FC<Props> = ({
         <GoodsImageOverlay />
         <GoodsUtilBtnContainer>
           <GoodsUtilBtn onClick={handleToWish}>
-            {isWished ? <BsFillHeartFill size={20} /> : <BsHeart size={20} />}
+            {isWished ? <BsFillHeartFill size={20} fill={theme.primary} /> : <BsHeart size={20} />}
           </GoodsUtilBtn>
           <GoodsUtilBtn onClick={handleClickUtliButton}>
             <BsFillBucketFill size={20} />

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -62,7 +62,7 @@ const GoodsItem: React.FC<Props> = ({
     async (e: React.MouseEvent) => {
       e.stopPropagation();
       try {
-        const result = await (isWished ? deleteWish(id) : postWish(id));
+        const result = isWished ? await deleteWish(id) : await postWish(id);
         if (result) setIsWished(!isWished);
       } catch (error) {
         console.log(error);

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsAmount/GoodsAmount.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsAmount/GoodsAmount.tsx
@@ -156,7 +156,7 @@ const TotalPrice = styled.div`
 `;
 
 const OverStock = styled.div`
-  font-size: 1.875rem;
+  font-size: 1.25rem;
   color: ${theme.warning};
 `;
 

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
@@ -13,15 +13,7 @@ interface Props {
   onOrder: () => void;
 }
 
-const GoodsButtons: React.FC<Props> = ({
-  goodsId,
-  amount,
-  isWish,
-  fetchCheckStock,
-  onToggleWish,
-  addToCart,
-  onOrder,
-}) => {
+const GoodsButtons: React.FC<Props> = ({ isWish, onToggleWish, addToCart, onOrder }) => {
   return (
     <>
       <GoodsButtonsContainer>

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
@@ -2,6 +2,7 @@ import React, { RefObject, useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import { FaRegHeart, FaHeart } from 'react-icons/fa';
 import { Link } from '@src/lib/CustomRouter';
+import theme from '@src/theme/theme';
 
 interface Props {
   isWish: boolean;
@@ -17,7 +18,7 @@ const GoodsButtons: React.FC<Props> = ({ isWish, onToggleWish, addToCart, onOrde
   return (
     <>
       <GoodsButtonsContainer>
-        <WishButton onClick={onToggleWish}>{isWish ? <FaHeart /> : <FaRegHeart />}</WishButton>
+        <WishButton onClick={onToggleWish}>{isWish ? <FaHeart fill={theme.primary} /> : <FaRegHeart />}</WishButton>
         <CartButton onClick={addToCart}>장바구니</CartButton>
         <OrderButton onClick={onOrder}>바로 구매</OrderButton>
       </GoodsButtonsContainer>

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -44,13 +44,12 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
   };
 
   const addToCart = useCallback(async () => {
-    if (disabled) return;
+    await fetchCheckStock;
+    if (isOver) return;
     setDisabled(true);
     try {
-      if (!isOver) {
-        await createCart({ goodsId: id, amount });
-        push('/cart');
-      }
+      await createCart({ goodsId: id, amount });
+      push('/cart');
     } catch (error) {
       console.log(error);
     } finally {

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -12,6 +12,7 @@ interface Props {
   goods: DetailGoods;
 }
 
+// TODO: 에러 및 구매 불가 안내 (토스트 팝업)
 const GoodsInteractive: React.FC<Props> = ({ goods }) => {
   const { id, title, price, deliveryFee = 0, discountRate = 0, isWish = false } = goods;
   const pushToOrderPage = usePushToOrderPage();

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -6,6 +6,7 @@ import { deleteWish, postWish } from '@src/apis/wishAPI';
 import { getGoodsStockCount } from '@src/apis/goodsAPI';
 import { createCart } from '@src/apis/cartAPI';
 import usePushToOrderPage from '@src/hooks/usePushToOrderPage';
+import { usePushHistory } from '@src/lib/CustomRouter';
 
 interface Props {
   goods: DetailGoods;
@@ -14,45 +15,60 @@ interface Props {
 const GoodsInteractive: React.FC<Props> = ({ goods }) => {
   const { id, title, price, deliveryFee = 0, discountRate = 0, isWish = false } = goods;
   const pushToOrderPage = usePushToOrderPage();
+  const push = usePushHistory();
 
   const [isWished, setIsWished] = useState(isWish);
   const [isOver, setIsOver] = useState(false);
   const [amount, setAmount] = useState(0);
+  const [disabled, setDisabled] = useState(false);
 
   const handleToWish = useCallback(async () => {
-    const result = await (isWished ? deleteWish(id) : postWish(id));
-    if (result) setIsWished(!isWished);
+    if (disabled) return;
+    setDisabled(true);
+    try {
+      const result = await (isWished ? deleteWish(id) : postWish(id));
+      if (result) setIsWished(!isWished);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setDisabled(false);
+    }
   }, [isWished]);
 
-  // const handleToWish = useCallback(async () => {}, []);
-  const handleAddToCart = useCallback(() => {
-    console.log('장바구니 추가 API', 'goods id:', id);
-  }, []);
-
-  const handleAddToOrder = () => {
+  const handleAddToOrder = async () => {
+    await fetchCheckStock;
+    if (isOver) return;
     const orderGoods: GoodsBeforeOrder = { goods, amount };
     pushToOrderPage([orderGoods]);
   };
 
   const addToCart = useCallback(async () => {
-    console.log('장바구니 추가 API', 'goods id:', id);
-    if (isOver) {
-      // 수량 초과 모달
-    } else {
-      const result = await createCart({ goodsId: id, amount });
-      // 장바구니 이동 안내 모달
+    if (disabled) return;
+    setDisabled(true);
+    try {
+      if (!isOver) {
+        await createCart({ goodsId: id, amount });
+        push('/cart');
+      }
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setDisabled(false);
     }
-  }, [amount]);
+  }, [amount, isOver]);
 
   const fetchCheckStock = async (goodsId: number) => {
+    if (disabled) return;
+    setDisabled(true);
     try {
       const data = await getGoodsStockCount(goodsId);
       const stock = data.result;
       if (stock < amount) setIsOver(true);
       else setIsOver(false);
     } catch (e) {
-      // TODO: 구매 불가능한 상태에 대한 처리 필요.
       setIsOver(false);
+    } finally {
+      setDisabled(false);
     }
   };
 

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -38,14 +38,14 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
 
   const handleAddToOrder = async () => {
     await fetchCheckStock;
-    if (isOver) return;
+    if (isOver || disabled || amount === 0) return;
     const orderGoods: GoodsBeforeOrder = { goods, amount };
     pushToOrderPage([orderGoods]);
   };
 
   const addToCart = useCallback(async () => {
     await fetchCheckStock;
-    if (isOver) return;
+    if (isOver || disabled || amount === 0) return;
     setDisabled(true);
     try {
       await createCart({ goodsId: id, amount });

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -25,7 +25,7 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
     if (disabled) return;
     setDisabled(true);
     try {
-      const result = await (isWished ? deleteWish(id) : postWish(id));
+      const result = isWished ? await deleteWish(id) : await postWish(id);
       if (result) setIsWished(!isWished);
     } catch (error) {
       console.log(error);

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -17,12 +17,10 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
   const { id, title, price, deliveryFee = 0, discountRate = 0, isWish = false } = goods;
   const pushToOrderPage = usePushToOrderPage();
   const push = usePushHistory();
-
   const [isWished, setIsWished] = useState(isWish);
   const [isOver, setIsOver] = useState(false);
   const [amount, setAmount] = useState(0);
   const [disabled, setDisabled] = useState(false);
-
   const handleToWish = useCallback(async () => {
     if (disabled) return;
     setDisabled(true);
@@ -34,17 +32,15 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
     } finally {
       setDisabled(false);
     }
-  }, [isWished]);
+  }, [isWished, disabled]);
 
-  const handleAddToOrder = async () => {
-    await fetchCheckStock;
+  const handleAddToOrder = useCallback(async () => {
     if (isOver || disabled || amount === 0) return;
     const orderGoods: GoodsBeforeOrder = { goods, amount };
     pushToOrderPage([orderGoods]);
-  };
+  }, [isOver, disabled, amount]);
 
   const addToCart = useCallback(async () => {
-    await fetchCheckStock;
     if (isOver || disabled || amount === 0) return;
     setDisabled(true);
     try {
@@ -55,13 +51,13 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
     } finally {
       setDisabled(false);
     }
-  }, [amount, isOver]);
+  }, [isOver, amount, disabled]);
 
-  const fetchCheckStock = async (goodsId: number) => {
+  const fetchCheckStock = async () => {
     if (disabled) return;
     setDisabled(true);
     try {
-      const data = await getGoodsStockCount(goodsId);
+      const data = await getGoodsStockCount(id);
       const stock = data.result;
       if (stock < amount) setIsOver(true);
       else setIsOver(false);
@@ -73,8 +69,13 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
   };
 
   useEffect(() => {
-    fetchCheckStock(id);
+    fetchCheckStock();
   }, [amount]);
+
+  useEffect(() => {
+    setIsWished(isWish);
+    setAmount(0);
+  }, [id]);
 
   return (
     <div>

--- a/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
+++ b/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
@@ -1,5 +1,6 @@
 import { createCart } from '@src/apis/cartAPI';
 import { getGoodsDetail, getGoodsStockCount } from '@src/apis/goodsAPI';
+import { usePushHistory } from '@src/lib/CustomRouter';
 import MainImage from '@src/pages/GoodsDetail/GoodsImageSection/Mainimage/MainImage';
 import GoodsInfo from '@src/pages/GoodsDetail/GoodsInfo/GoodsInfo';
 import GoodsAmount from '@src/pages/GoodsDetail/GoodsInteractive/GoodsAmount/GoodsAmount';
@@ -13,9 +14,12 @@ interface Props {
 }
 
 const CartForm: React.FC<Props> = ({ goodsId }) => {
+  const push = usePushHistory();
+
   const [goods, setGoods] = useState<DetailGoods | null>(null);
   const [isOver, setIsOver] = useState(false);
   const [amount, setAmount] = useState(0);
+  const [disabled, setDisabled] = useState(false);
 
   const fetchDetailGoods = async (goodsId: number) => {
     try {
@@ -38,11 +42,17 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
   };
 
   const addToCart = useCallback(async () => {
-    if (isOver) {
-      // 수량 초과 모달
-    } else {
-      // 장바구니 이동
-      const result = await createCart({ goodsId, amount });
+    if (disabled) return;
+    setDisabled(true);
+    try {
+      if (!isOver) {
+        await createCart({ goodsId, amount });
+        push('/cart');
+      }
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setDisabled(false);
     }
   }, [amount]);
 

--- a/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
+++ b/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
@@ -44,7 +44,7 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
 
   const addToCart = useCallback(async () => {
     await fetchCheckStock;
-    if (isOver) return;
+    if (isOver || disabled || amount === 0) return;
     setDisabled(true);
     try {
       await createCart({ goodsId, amount });
@@ -54,7 +54,7 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
     } finally {
       setDisabled(false);
     }
-  }, [amount]);
+  }, [amount, isOver]);
 
   useEffect(() => {
     fetchDetailGoods(goodsId);

--- a/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
+++ b/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
@@ -43,13 +43,12 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
   };
 
   const addToCart = useCallback(async () => {
-    if (disabled) return;
+    await fetchCheckStock;
+    if (isOver) return;
     setDisabled(true);
     try {
-      if (!isOver) {
-        await createCart({ goodsId, amount });
-        push('/cart');
-      }
+      await createCart({ goodsId, amount });
+      push('/cart');
     } catch (error) {
       console.log(error);
     } finally {

--- a/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
+++ b/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
@@ -43,7 +43,6 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
   };
 
   const addToCart = useCallback(async () => {
-    await fetchCheckStock;
     if (isOver || disabled || amount === 0) return;
     setDisabled(true);
     try {
@@ -54,7 +53,7 @@ const CartForm: React.FC<Props> = ({ goodsId }) => {
     } finally {
       setDisabled(false);
     }
-  }, [amount, isOver]);
+  }, [amount, disabled, isOver]);
 
   useEffect(() => {
     fetchDetailGoods(goodsId);

--- a/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
+++ b/frontend/client/src/portal/CartModal/CartForm/CartForm.tsx
@@ -13,6 +13,7 @@ interface Props {
   goodsId: number;
 }
 
+// TODO: 에러 및 구매 불가 안내 (토스트 팝업)
 const CartForm: React.FC<Props> = ({ goodsId }) => {
   const push = usePushHistory();
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

상품 상세 및 상품 컴포넌트 API 연동

![상품 상세 및 상품 컴포넌트 API 연동](https://user-images.githubusercontent.com/45394360/130002733-28b9bd66-b7d9-4a35-b34c-ea9cbcc0323e.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 클라이언트, 백엔드 서버 실행 결과 이상 없었나요?
- [x] 테스트를 실행해봤나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 카트모달 장바구니 페이지 이동 적용
- [x] auth setting 미들웨어 추가
- [x] 메인 상품 목록 wish 여부 확인
- [x] 연관 상품 클릭시 wish, amount 초기화

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 회원, 비회원 모두 접근할 수 있는 요청을 위해 setAuthenticate 함수를 추가했습니다.
- 클라이언트 에러 처리는 토스트 팝업 적용 이후 처리하도록 하겠습니다. :)
- 이제 어드민 상품 관리 페이지 시작!