### PR TITLE
[Deploy] 배포 파이프라인 에서 node_module 제거해서 번들링 결과만 배포

### DIFF
--- a/.github/workflows/deploy-actions.yaml
+++ b/.github/workflows/deploy-actions.yaml
@@ -32,7 +32,9 @@ jobs:
         working-directory: ./frontend/client
 
       - name: Build in Client App
-        run: npm run build
+        run: |
+          npm run build
+          rm -r node_modules
         working-directory: ./frontend/client
 
       - name: Install Dependency in Admin App
@@ -43,6 +45,7 @@ jobs:
       - name: Build Dependency in Admin App
         run: |
           npm run build
+          rm -r node_modules
         working-directory: ./frontend/admin
 
       - name: Install Dependency in Server
@@ -50,7 +53,9 @@ jobs:
         working-directory: ./backend
 
       - name: Build in Server
-        run: npm run build
+        run: |
+          npm run build
+          rm -r node_modules
         working-directory: ./backend
 
       - name: Move Bundle Files to Server Public

--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -8,7 +8,7 @@ SERVER_APP_REPOSITORY=/home/ubuntu/store-5/backend
 
 cd $SERVER_APP_REPOSITORY
 
-pm2 start ./dist/bundle.js > $HOME/deploy_after.txt
+pm2 start ./dist/bundle.js 2> $HOME/deploy_after.txt
 
 rm -r $HOME/touch_CICD.txt
 

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -6,7 +6,7 @@ HOME=/home/ubuntu
 
 cd $HOME
 
-pm2 delete all > $HOME/deploy_before.txt
+pm2 delete all 2> $HOME/deploy_before.txt
 
 rm -rf store-5
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

AWS EC2(small) 인스턴스에 배포를 하는 git action(`Build & Deploy`) 배포 과정에서 node_module도 함께 배포가 되고 있습니다.

문제는 AWS EC2 에 Code Agent가 default 설정으로 revision(이전 배포파일)을 5개까지 유지하고 있었고 5개 버젼의 배포 파일들을 서버가 가지고 있을 경우,  저희 EC2 저장용량(8GB)를 넘게 되어서 현재는 이전 버젼의 배포파일을 1개까지만 유지하도록 설정을 변경했습니다.

하지만 node_module자체는 번들링이된 상태에서는 쓸모가 없기 때문에 제거해줘도 좋을 것 같은 판단으로 git action 에서 node_modules 디렉토리를 지워주는 스크립트를 추가했습니다.

그리고 현재 이미지를 S3가 아닌 서버 폴더에 저장하는 형태라 언제 서버가 다운될 지 모르는 상황이라 최대한 줄여보고 서둘러 `S3-Multer`를 적용하는 방법을 찾아봐야할 것 같습니다.

- 현재 기준으로  2개의 배포 Revision을 들고 있는 서버 용량 (대략 1GB 정도)
 
<img width="753" alt="스크린샷 2021-08-19 오후 5 33 24" src="https://user-images.githubusercontent.com/20085849/130036253-d6f5ec14-9dec-4c49-aa21-fe12657d2946.png">
