### PR TITLE
[Deploy] CodeDeploy 로 NVM 사용시 Node의 경로를 지정 

### DIFF
--- a/.github/workflows/deploy-actions.yaml
+++ b/.github/workflows/deploy-actions.yaml
@@ -32,7 +32,9 @@ jobs:
         working-directory: ./frontend/client
 
       - name: Build in Client App
-        run: npm run build
+        run: |
+          npm run build
+          rm -r node_modules
         working-directory: ./frontend/client
 
       - name: Install Dependency in Admin App
@@ -43,6 +45,7 @@ jobs:
       - name: Build Dependency in Admin App
         run: |
           npm run build
+          rm -r node_modules
         working-directory: ./frontend/admin
 
       - name: Install Dependency in Server
@@ -50,7 +53,9 @@ jobs:
         working-directory: ./backend
 
       - name: Build in Server
-        run: npm run build
+        run: |
+          npm run build
+          rm -r node_modules
         working-directory: ./backend
 
       - name: Move Bundle Files to Server Public

--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -8,7 +8,7 @@ SERVER_APP_REPOSITORY=/home/ubuntu/store-5/backend
 
 cd $SERVER_APP_REPOSITORY
 
-pm2 start ./dist/bundle.js > $HOME/deploy_after.txt
+pm2 start ./dist/bundle.js 2> $HOME/deploy_after.txt
 
 rm -r $HOME/touch_CICD.txt
 

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -6,7 +6,7 @@ HOME=/home/ubuntu
 
 cd $HOME
 
-pm2 delete all > $HOME/deploy_before.txt
+pm2 delete all 2> $HOME/deploy_before.txt
 
 rm -rf store-5
 

--- a/scripts/before_deploy.sh
+++ b/scripts/before_deploy.sh
@@ -6,6 +6,8 @@ HOME=/home/ubuntu
 
 cd $HOME
 
+npm install pm2 -g
+
 pm2 delete all 2> $HOME/deploy_before.txt
 
 rm -rf store-5


### PR DESCRIPTION
## :bookmark_tabs: 제목

배포시 지속적으로 PM2가 실행되지않는걸 확인해보니 Code Deploy의 Hook을 통해 스크립트를 실행시 node경로는 제대로 못찾는 것을 확인하고 .bash_rc에서 nvm을 통해 node 경로를 찾는 코드를 배포 훅 스크립트 시작부분에 추가했습니다.

<img width="802" alt="스크린샷 2021-08-19 오후 7 11 42" src="https://user-images.githubusercontent.com/20085849/130051200-836c8616-5771-40e2-ad95-4af30f55244b.png">

먼길을 돌아온느낌입니다. 이제진짜 자동 배포입니다.
