### PR TITLE
[feature/104] 주문 조회 Pagination API 추가 후 Client App 과 연동

### DIFF
--- a/backend/src/controller/order.controller.ts
+++ b/backend/src/controller/order.controller.ts
@@ -1,9 +1,27 @@
 import { OrderService } from './../service/order.service';
 import { Request, Response } from 'express';
 import { CreateOrderRequest } from '../types/request/order.request';
+import { GetAllOrderByUserIdProps } from '../types/Order';
+import { BadRequestError } from '../errors/client.error';
+import { INVALID_DATA } from '../constants/client-error-name';
+
 async function getOrders(req: Request, res: Response) {
   const userId = req.userId;
   const result = await OrderService.getOrders(userId);
+  res.status(200).send({ result });
+}
+
+async function getOrdersPagination(req: Request, res: Response) {
+  const { page, limit } = req.query;
+  if (page === undefined || limit === undefined) {
+    throw new BadRequestError(INVALID_DATA);
+  }
+  const userId = req.userId;
+  const OrderListQueryParams: GetAllOrderByUserIdProps = {
+    page: Number(page),
+    limit: Number(limit),
+  };
+  const result = await OrderService.getOrdersPagination(OrderListQueryParams, userId);
   res.status(200).send({ result });
 }
 
@@ -11,10 +29,11 @@ async function createOrder(req: CreateOrderRequest, res: Response) {
   const userId = req.userId;
   const body = req.body;
   const result = await OrderService.createOrder(userId, body);
-  res.status(200).send({ result });
+  res.status(200).send(result);
 }
 
 export const OrderController = {
   getOrders,
+  getOrdersPagination,
   createOrder,
 };

--- a/backend/src/controller/order.controller.ts
+++ b/backend/src/controller/order.controller.ts
@@ -5,12 +5,6 @@ import { GetAllOrderByUserIdProps } from '../types/Order';
 import { BadRequestError } from '../errors/client.error';
 import { INVALID_DATA } from '../constants/client-error-name';
 
-async function getOrders(req: Request, res: Response) {
-  const userId = req.userId;
-  const result = await OrderService.getOrders(userId);
-  res.status(200).send({ result });
-}
-
 async function getOrdersPagination(req: Request, res: Response) {
   const { page, limit } = req.query;
   if (page === undefined || limit === undefined) {
@@ -33,7 +27,6 @@ async function createOrder(req: CreateOrderRequest, res: Response) {
 }
 
 export const OrderController = {
-  getOrders,
   getOrdersPagination,
   createOrder,
 };

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -134,9 +134,9 @@ async function createDefaultPayment() {
 }
 
 async function createDefaultCart() {
-  await CartService.createCart(1, 1, { amount: 1 });
-  await CartService.createCart(1, 2, { amount: 1 });
-  await CartService.createCart(1, 3, { amount: 1 });
+  // await CartService.createCart(1, 1, { amount: 1 });
+  // await CartService.createCart(1, 2, { amount: 1 });
+  // await CartService.createCart(1, 3, { amount: 1 });
 }
 
 async function createDefaultGoods() {

--- a/backend/src/entity/OrderItem.ts
+++ b/backend/src/entity/OrderItem.ts
@@ -35,9 +35,9 @@ export class OrderItem {
 
   @ManyToOne(() => Goods, (goods) => goods.id)
   @JoinColumn()
-  goods: number;
+  goods: Goods;
 
   @ManyToOne(() => OrderList, (orderList) => orderList.id)
   @JoinColumn()
-  orderList: number;
+  orderList: OrderList;
 }

--- a/backend/src/entity/OrderList.ts
+++ b/backend/src/entity/OrderList.ts
@@ -1,4 +1,12 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { OrderItem } from './OrderItem';
 import { Payment } from './Payment';
 import { User } from './User';
@@ -36,5 +44,8 @@ export class OrderList {
   payment: number;
 
   @ManyToOne(() => User, (user) => user.id)
-  user: number;
+  user: User;
+
+  @OneToMany(() => OrderItem, (order) => order.orderList)
+  orderItems: OrderItem[];
 }

--- a/backend/src/repository/order.item.repository.ts
+++ b/backend/src/repository/order.item.repository.ts
@@ -8,7 +8,11 @@ async function createOrderItem(
   orderListId: number,
   orderItemBody: CreateOrderItem
 ): Promise<OrderItem> {
-  return await getRepository(OrderItem).save({ ...orderItemBody, goods: goodsId, orderList: orderListId });
+  return await getRepository(OrderItem).save({
+    ...orderItemBody,
+    goods: { id: goodsId },
+    orderList: { id: orderListId },
+  });
 }
 
 async function getAllOrderItemByListId(orderListId: number): Promise<OrderItem[]> {

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -3,6 +3,7 @@ import { OrderList } from '../entity/OrderList';
 import { getRepository } from 'typeorm';
 import { DatabaseError } from '../errors/base.error';
 import { ORDER_LIST_DB_ERROR } from '../constants/database-error-name';
+import { PaginationProps } from '../types/Pagination';
 
 // TODO: thumbnail, 제목 : 볼펜 에디션 외 4건 이런식으로? 팀원들과 의논해야함.
 // 나중으로 일단 미룸
@@ -16,6 +17,26 @@ async function getOrders(userId: number): Promise<OrderList[]> {
       where: {
         user: userId,
       },
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(ORDER_LIST_DB_ERROR);
+  }
+}
+
+async function getOwnOrderTotalCount(userId: number): Promise<number> {
+  return await getRepository(OrderList).count();
+}
+
+async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId: number): Promise<OrderList[]> {
+  try {
+    return await getRepository(OrderList).find({
+      relations: ['payment'],
+      where: {
+        user: userId,
+      },
+      skip: offset,
+      take: limit,
     });
   } catch (err) {
     console.error(err);
@@ -40,5 +61,7 @@ async function createOrder(userId: number, body: CreateOrderBody): Promise<Order
 
 export const OrderListRepository = {
   getOrders,
+  getOwnOrderTotalCount,
+  getOwnOrdersPagination,
   createOrder,
 };

--- a/backend/src/router/order.router.ts
+++ b/backend/src/router/order.router.ts
@@ -5,7 +5,7 @@ import isAuthenticate from '../middlewares/is-authenticate';
 
 const router = express.Router();
 
-router.get('/', isAuthenticate, wrapAsync(OrderController.getOrders));
+router.get('/', isAuthenticate, wrapAsync(OrderController.getOrdersPagination));
 router.post('/', isAuthenticate, wrapAsync(OrderController.createOrder));
 
 export default router;

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -18,7 +18,7 @@ import {
   GetAllByKeywordProps,
   GetAllByUserIdProps,
 } from '../types/Goods';
-import { pagination } from '../utils/pagination';
+import { getTotalPage, pagination } from '../utils/pagination';
 import { BadRequestError } from '../errors/client.error';
 import { GOODS_DB_ERROR } from '../constants/database-error-name';
 import { CategoryRepository } from '../repository/category.repository';
@@ -260,10 +260,6 @@ function getListGoodsMeta(page: number, limit: number, totalCount: number): Good
     totalPage: getTotalPage(totalCount, limit),
     totalCount,
   };
-}
-
-function getTotalPage(totalCount: number, limit: number): number {
-  return Math.ceil(totalCount / limit);
 }
 
 export const GoodsService = {

--- a/backend/src/service/order.service.ts
+++ b/backend/src/service/order.service.ts
@@ -20,13 +20,6 @@ type OrderGoodsInfo = OrderItem & {
   goods: Goods;
 };
 
-async function getOrders(userId: number): Promise<GetOrderListResponse> {
-  const ordersResponse: GetOrderListResponse = [];
-  const orders = await OrderListRepository.getOrders(userId);
-  await Promise.all(orders.map((order) => processGetOrderData(order, ordersResponse)));
-  return ordersResponse;
-}
-
 async function getOrdersPagination(
   { page, limit }: GetAllOrderByUserIdProps,
   userId: number
@@ -41,8 +34,8 @@ async function getOrdersPagination(
   };
   const orders = await OrderListRepository.getOwnOrdersPagination(option, userId);
 
-  const processedOrderList: OrderListWithThumbnail[] = [];
-  await Promise.all(orders.map((order) => processGetOrderData(order, processedOrderList)));
+  const processedOrderList = await Promise.all(orders.map((order) => processAppendingThumbnailAndTitle(order)));
+
   return {
     meta: {
       page: newPage,
@@ -75,20 +68,26 @@ async function createOrderItem(orderedItem: OrderGoods, orderListId: number): Pr
   });
 }
 
-// TODO: (jiho) 함수형으로 리팩토링 필요해보이는 코드
-async function processGetOrderData(order: OrderList, ordersResponse: GetOrderListResponse) {
+async function processAppendingThumbnailAndTitle(order: OrderList): Promise<OrderListWithThumbnail> {
   const orderItems = await OrderItemRepository.getAllOrderItemByListId(order.id);
   if (orderItems.length < 1) throw new BadRequestError(INVALID_DATA);
-  const orderItemInfo = (await OrderItemRepository.findOrderGoodsInfoById(orderItems[0].id)) as OrderGoodsInfo;
+
+  // 가장 맨 처음 탐색되는 주문 아이템이 thumbnail이 된다.
+  const orderItemInfo = await OrderItemRepository.findOrderGoodsInfoById(orderItems[0].id);
   if (!orderItemInfo) throw new BadRequestError(INVALID_DATA);
+
   const count = orderItems.length - 1;
-  const title = `${orderItemInfo.goods.title}외 ${count}건 주문`;
+  const title = `${orderItemInfo.goods.title} 외 ${count}건 주문`;
   const thumbnailUrl = orderItemInfo.goods.thumbnailUrl;
-  ordersResponse.push({ ...order, title, thumbnailUrl });
+
+  return {
+    ...order,
+    title,
+    thumbnailUrl,
+  };
 }
 
 export const OrderService = {
-  getOrders,
   getOrdersPagination,
   createOrder,
 };

--- a/backend/src/types/Order.ts
+++ b/backend/src/types/Order.ts
@@ -9,3 +9,8 @@ export interface CreateOrderItem {
   discountRate: number;
   state: string;
 }
+
+export interface GetAllOrderByUserIdProps {
+  page: number;
+  limit: number;
+}

--- a/backend/src/types/Pagination.ts
+++ b/backend/src/types/Pagination.ts
@@ -1,0 +1,4 @@
+export interface PaginationProps {
+  offset: number;
+  limit: number;
+}

--- a/backend/src/types/response/order.response.ts
+++ b/backend/src/types/response/order.response.ts
@@ -1,8 +1,20 @@
 import { OrderList } from '../../entity/OrderList';
 
-interface GetOrderList extends OrderList {
+export interface OrderListMetaData {
+  page: number;
+  limit: number;
+  totalPage: number;
+  totalCount: number;
+}
+
+export interface OrderListWithThumbnail extends OrderList {
   title: string;
   thumbnailUrl: string;
 }
 
-export type GetOrderListResponse = GetOrderList[];
+export interface OrderListPaginationResponse {
+  meta?: OrderListMetaData;
+  orderList?: OrderListWithThumbnail[];
+}
+
+export type GetOrderListResponse = OrderListWithThumbnail[];

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -2,3 +2,5 @@ const calculateTotalPage = (count: number, limit: number): number => Math.floor(
 const calculateOffset = (page: number, limit: number): number => (page * limit > limit ? (page - 1) * limit : 0);
 
 export const pagination = { calculateTotalPage, calculateOffset };
+
+export const getTotalPage = (totalCount: number, limit: number): number => Math.ceil(totalCount / limit);

--- a/frontend/client/src/apis/orderAPI.ts
+++ b/frontend/client/src/apis/orderAPI.ts
@@ -1,3 +1,4 @@
+import { Order, OrderPaginationResult } from '@src/types/Order';
 import { APIResponse, checkedFetch } from './base';
 
 interface GoodsInfoForOrder {
@@ -15,7 +16,7 @@ interface SubmitOrderBody {
   paymentId: number;
 }
 
-export const submitOrder = async (orderData: SubmitOrderBody): Promise<APIResponse<any>> => {
+export const submitOrder = async (orderData: SubmitOrderBody): Promise<boolean> => {
   const res = await checkedFetch(`/api/order`, {
     method: 'POST',
     credentials: 'include',
@@ -24,5 +25,23 @@ export const submitOrder = async (orderData: SubmitOrderBody): Promise<APIRespon
       'Content-Type': 'application/json',
     },
   });
+  return true;
+};
+
+export const getOrders = async (page: number, limit: number): Promise<APIResponse<OrderPaginationResult>> => {
+  const res = await checkedFetch(`/api/order?page=${page}&limit=${limit}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
   return await res.json();
 };
+
+const OrderAPI = {
+  submitOrder,
+  getOrders,
+};
+
+export default OrderAPI;

--- a/frontend/client/src/components/Header/Header.tsx
+++ b/frontend/client/src/components/Header/Header.tsx
@@ -49,7 +49,7 @@ type HeaderContainerProp = {
 
 const ScrolledStyle = css`
   position: sticky;
-  height: 8vh;
+  height: 13vh;
 `;
 
 const Sentinel = styled.div<HeaderContainerProp>`

--- a/frontend/client/src/pages/GoodsDetail/RelationSection/RelationSection.tsx
+++ b/frontend/client/src/pages/GoodsDetail/RelationSection/RelationSection.tsx
@@ -14,8 +14,8 @@ const RelationSection: React.FC<Props> = ({ categoryName }) => {
 
   const fetchDetailGoods = async (categoryName: string) => {
     try {
-      const data = await getRelationGoods(categoryName);
-      setRelationGoodsList(data.result.goodsList);
+      const { result } = await getRelationGoods(categoryName);
+      setRelationGoodsList(result.goodsList);
     } catch (e) {
       setRelationGoodsList([]);
     }

--- a/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
+++ b/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
@@ -29,7 +29,12 @@ const MyAddressView = () => {
   }
 
   useEffect(() => {
-    fetchAddresses();
+    try {
+      fetchAddresses();
+    } catch (err) {
+      console.error(err);
+      alert('사용자 주소를 불러오는데 실패했습니다. 서버오류');
+    }
   }, []);
 
   const defaultAddress = addresses.find((address) => address.isDefault);

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -66,6 +66,7 @@ const OrderCardList = styled.ul`
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
+  height: 500px;
 `;
 
 export default MyOrderListView;

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -1,0 +1,49 @@
+import OrderAPI from '@src/apis/orderAPI';
+import styled from 'styled-components';
+
+import { Order, OrderPaginationResult } from '@src/types/Order';
+import React, { useEffect, useState } from 'react';
+import Topic from '@src/components/Topic/Topic';
+import Paginator from '@src/components/Paginator/Paginator';
+
+const DEFAULT_START_PAGE = 1;
+const LIMIT_COUNT_ORDER = 4;
+
+const MyOrderListView = () => {
+  const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
+  const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
+
+  const fetchOrderList = async () => {
+    const { result } = await OrderAPI.getOrders(1, LIMIT_COUNT_ORDER);
+    setOrderPaginationResult(result);
+  };
+
+  useEffect(() => {
+    fetchOrderList();
+  }, [currentPage]);
+
+  return (
+    <MyOrderListViewContainer>
+      <Topic>주문 조회 페이지</Topic>
+      {orderPaginationResult && (
+        <>
+          {orderPaginationResult?.orderList.map((order) => {
+            return <li key={order.id}>{order.title}</li>;
+          })}
+          <Paginator
+            totalPage={orderPaginationResult?.meta.totalPage}
+            currentPage={orderPaginationResult?.meta.page}
+            setPage={setCurrentPage}
+          />
+        </>
+      )}
+    </MyOrderListViewContainer>
+  );
+};
+
+const MyOrderListViewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export default MyOrderListView;

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -7,7 +7,7 @@ import Topic from '@src/components/Topic/Topic';
 import Paginator from '@src/components/Paginator/Paginator';
 
 const DEFAULT_START_PAGE = 1;
-const LIMIT_COUNT_ORDER = 4;
+const LIMIT_COUNT_ORDER = 10;
 
 const MyOrderListView = () => {
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
@@ -19,7 +19,12 @@ const MyOrderListView = () => {
   };
 
   useEffect(() => {
-    fetchOrderList();
+    try {
+      fetchOrderList();
+    } catch (err) {
+      console.error(err);
+      alert('주문정보 불러오는데 실패했습니다. 서버오류');
+    }
   }, [currentPage]);
 
   return (

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -1,20 +1,22 @@
 import OrderAPI from '@src/apis/orderAPI';
 import styled from 'styled-components';
 
-import { Order, OrderPaginationResult } from '@src/types/Order';
+import { OrderPaginationResult } from '@src/types/Order';
 import React, { useEffect, useState } from 'react';
 import Topic from '@src/components/Topic/Topic';
 import Paginator from '@src/components/Paginator/Paginator';
+import { convertYYYYMMDD } from '@src/utils/dateHelper';
+import OrderCard from '@src/pages/MyPage/MyOrderListView/OrderCard';
 
 const DEFAULT_START_PAGE = 1;
-const LIMIT_COUNT_ORDER = 10;
+const LIMIT_COUNT_ORDER = 4;
 
 const MyOrderListView = () => {
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
 
   const fetchOrderList = async () => {
-    const { result } = await OrderAPI.getOrders(1, LIMIT_COUNT_ORDER);
+    const { result } = await OrderAPI.getOrders(currentPage, LIMIT_COUNT_ORDER);
     setOrderPaginationResult(result);
   };
 
@@ -26,28 +28,43 @@ const MyOrderListView = () => {
       alert('주문정보 불러오는데 실패했습니다. 서버오류');
     }
   }, [currentPage]);
-
   return (
     <MyOrderListViewContainer>
-      <Topic>주문 조회 페이지</Topic>
+      <Topic>반가워요! 주문 내역입니다.</Topic>
+      <p>주문 조회 내역 총 {orderPaginationResult?.meta.totalCount} 건</p>
       {orderPaginationResult && (
-        <>
-          {orderPaginationResult?.orderList.map((order) => {
-            return <li key={order.id}>{order.title}</li>;
-          })}
+        <OrderPaginationContainer>
+          <OrderCardList>
+            {orderPaginationResult?.orderList.map((order) => (
+              <OrderCard key={order.id} order={order} />
+            ))}
+          </OrderCardList>
+
           <Paginator
             totalPage={orderPaginationResult?.meta.totalPage}
             currentPage={orderPaginationResult?.meta.page}
             setPage={setCurrentPage}
           />
-        </>
+        </OrderPaginationContainer>
       )}
     </MyOrderListViewContainer>
   );
 };
 
 const MyOrderListViewContainer = styled.div`
+  width: 900px;
   display: flex;
+  flex-direction: column;
+`;
+
+const OrderPaginationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const OrderCardList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
   flex-direction: column;
 `;
 

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -5,7 +5,6 @@ import { OrderPaginationResult } from '@src/types/Order';
 import React, { useEffect, useState } from 'react';
 import Topic from '@src/components/Topic/Topic';
 import Paginator from '@src/components/Paginator/Paginator';
-import { convertYYYYMMDD } from '@src/utils/dateHelper';
 import OrderCard from '@src/pages/MyPage/MyOrderListView/OrderCard';
 
 const DEFAULT_START_PAGE = 1;

--- a/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
@@ -1,0 +1,102 @@
+import HighlightedText from '@src/components/HighlightedText/HighlightedText';
+import { Order } from '@src/types/Order';
+import { convertYYYYMMDD } from '@src/utils/dateHelper';
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  order: Order;
+}
+
+const OrderCard: React.FC<Props> = ({ order }) => {
+  return (
+    <OrderCardContainer>
+      <OrderCardDateAndIdCell>
+        <OrderIdText>{order.id}</OrderIdText>
+        {convertYYYYMMDD(new Date(order.createdAt))}
+      </OrderCardDateAndIdCell>
+      <OrderCardProductInfo>
+        <ThumbnailImg src={order.thumbnailUrl} />
+        <OrderCardProductInfoTitle>{order.title}</OrderCardProductInfoTitle>
+      </OrderCardProductInfo>
+      <OrderCardStateInfo>
+        <OrderStateText>
+          <HighlightedText fontSize={'10px'}>{order.state}</HighlightedText>
+        </OrderStateText>
+      </OrderCardStateInfo>
+      <OrderCardDeliveryInfo>
+        <div>{order.address}</div>
+        <div>{order.subAddress}</div>
+      </OrderCardDeliveryInfo>
+      <OrderControlContainer>
+        <button>자세히 보기</button>
+      </OrderControlContainer>
+    </OrderCardContainer>
+  );
+};
+
+const OrderCardContainer = styled.li`
+  display: grid;
+  grid-template-columns: 1fr 3fr 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  border-bottom: 1px solid black;
+  height: 120px;
+  width: 100%;
+  padding: 10px;
+`;
+
+const OrderCardDateAndIdCell = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const OrderIdText = styled.p`
+  cursor: pointer;
+  opacity: 0.8;
+  padding: 1rem;
+  &:hover {
+    opacity: 1;
+    outline-color: black;
+    outline-width: 1px;
+  }
+`;
+
+const OrderCardProductInfo = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
+
+const OrderCardProductInfoTitle = styled.div`
+  margin-left: 1rem;
+`;
+
+const ThumbnailImg = styled.img`
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+`;
+
+const OrderCardStateInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const OrderStateText = styled.div``;
+
+const OrderCardDeliveryInfo = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const OrderControlContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export default OrderCard;

--- a/frontend/client/src/pages/MyPage/MyPage.tsx
+++ b/frontend/client/src/pages/MyPage/MyPage.tsx
@@ -8,6 +8,7 @@ import MyWishListView from '@src/pages/MyPage/MyWishListView/MyWishListView';
 import styled from 'styled-components';
 import MyAddressView from '@src/pages/MyPage/MyAddressView/MyAddressView';
 import useUserState from '@src/hooks/useUserState';
+import MyOrderListView from '@src/pages/MyPage/MyOrderListView/MyOrderListView';
 
 const MyPage = () => {
   const [user] = useUserState();
@@ -23,6 +24,9 @@ const MyPage = () => {
       </MyPageNavContainer>
       <MyPageContentContainer>
         <Routes>
+          <Route path='/mypage/order'>
+            <MyOrderListView />
+          </Route>
           <Route path='/mypage/address'>
             <MyAddressView />
           </Route>

--- a/frontend/client/src/pages/MyPage/MyPageNavBar/MyPageNavBar.tsx
+++ b/frontend/client/src/pages/MyPage/MyPageNavBar/MyPageNavBar.tsx
@@ -20,6 +20,9 @@ const MyPageNavBar = () => {
       <SubNav title='상품'>
         <NavItem name='찜 리스트' to={'/mypage/wish'} />
       </SubNav>
+      <SubNav title='주문/배송'>
+        <NavItem name='내 주문' to={'/mypage/order'} />
+      </SubNav>
     </div>
   );
 };

--- a/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
@@ -20,7 +20,7 @@ const MyWishListView = () => {
 
   useEffect(() => {
     fetchWishGoodsList();
-  }, []);
+  }, [currentPage]);
 
   return (
     <MyWishListViewContainer>

--- a/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
@@ -19,7 +19,12 @@ const MyWishListView = () => {
   };
 
   useEffect(() => {
-    fetchWishGoodsList();
+    try {
+      fetchWishGoodsList();
+    } catch (err) {
+      console.error(err);
+      alert('찜 리스트를 불러오는데 실패했습니다. 서버오류');
+    }
   }, [currentPage]);
 
   return (

--- a/frontend/client/src/types/Order.ts
+++ b/frontend/client/src/types/Order.ts
@@ -1,4 +1,16 @@
 import { Payment } from '@src/types/Payment';
+import { ThumbnailGoods } from './Goods';
+
+export interface OrderItem {
+  id: string;
+  amount: number;
+  price: number;
+  discountRate: number;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+  goods: ThumbnailGoods;
+}
 
 export interface Order {
   id: number;
@@ -13,6 +25,7 @@ export interface Order {
   zipCode: string;
   updatedAt: string;
   createdAt: string;
+  orderItems: OrderItem[];
 }
 
 export interface OrderPaginationResult {

--- a/frontend/client/src/types/Order.ts
+++ b/frontend/client/src/types/Order.ts
@@ -1,0 +1,26 @@
+import { Payment } from '@src/types/Payment';
+
+export interface Order {
+  id: number;
+  address: string;
+  orderMemo: string;
+  receiver: string;
+  state: string;
+  subAddress: string;
+  thumbnailUrl: string;
+  title: string;
+  payment: Payment;
+  zipCode: string;
+  updatedAt: Date;
+  createdAt: Date;
+}
+
+export interface OrderPaginationResult {
+  orderList: Order[];
+  meta: {
+    page: number;
+    limit: number;
+    totalPage: number;
+    totalCount: number;
+  };
+}

--- a/frontend/client/src/types/Order.ts
+++ b/frontend/client/src/types/Order.ts
@@ -11,8 +11,8 @@ export interface Order {
   title: string;
   payment: Payment;
   zipCode: string;
-  updatedAt: Date;
-  createdAt: Date;
+  updatedAt: string;
+  createdAt: string;
 }
 
 export interface OrderPaginationResult {

--- a/frontend/client/src/utils/dateHelper.ts
+++ b/frontend/client/src/utils/dateHelper.ts
@@ -1,0 +1,5 @@
+export const convertYYYYMMDD = (date: Date) => {
+  var mm = date.getMonth() + 1;
+  var dd = date.getDate();
+  return [date.getFullYear(), (mm > 9 ? '' : '0') + mm, (dd > 9 ? '' : '0') + dd].join('-');
+};

--- a/frontend/client/src/utils/numberHelper.ts
+++ b/frontend/client/src/utils/numberHelper.ts
@@ -1,0 +1,8 @@
+export const fullNumberFormat = (data: number, idx: number): string => {
+  const numberStr = String(data);
+  if (numberStr.length > idx) {
+    return numberStr;
+  } else {
+    return '0'.repeat(numberStr.length - idx) + numberStr;
+  }
+};


### PR DESCRIPTION
## :bookmark_tabs: 제목

주문 조회 관련 API 가 있었지만 Pagination이 안되서 새로 Pagination을 구성했습니다. 기존의 OrderList API 를 제거해야할지 용도가 있을지 같이 이야기해보고 결정하겠습니다.

주문조조회관련 기능을 간단히 리스트만 만들었습니다. Order에서 OrderItem을 자세히보려면 모달이 필요할 듯합니다. 모달은 다른 PR로 올리도록하겠습니다.

![주문조회](https://user-images.githubusercontent.com/20085849/130088760-3e4feaf3-12f9-484a-abf3-fc3883a9a6b8.gif)


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] OrderListPagination API 개발
- [x] MyPage Order List UI/UX 개발
## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Pagination API를 개발하면서 느낀점이지만 각 API에 맞는 Pagination Props를 일일히 만들 필요는 없을 것 같습니다.

Pagination을 위한 속성들(limit, offset)은 항상정해져 있으니 나머지는 다른 값들(userId, category ...) 은 argument로 받으면 될 듯합니다.  
