### PR TITLE
[feature/142] 마이페이지 주문리스트 기능 확장 및 리팩토링 (관련 OrderItem 확장해서 보여주기)

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -7,7 +7,7 @@ import { Category } from './entity/Category';
 import { Goods } from './entity/Goods';
 import { GoodsImg } from './entity/GoodsImg';
 import { OrderItem } from './entity/OrderItem';
-import { OrderList } from './entity/OrderList';
+import { Order } from './entity/Order';
 import { Payment } from './entity/Payment';
 import { Promotion } from './entity/Promotion';
 import { User } from './entity/User';
@@ -33,7 +33,7 @@ export default async function () {
       DeliveryInfo,
       Cart,
       OrderItem,
-      OrderList,
+      Order,
       Goods,
       GoodsImg,
       Category,
@@ -53,7 +53,6 @@ async function populate() {
   await createDefaultGoods();
   await createDefaultPromotions();
   await createDefaultPayment();
-  await createDefaultOrderList();
 }
 
 async function createDefaultUser(name: string) {
@@ -122,25 +121,6 @@ async function createDefaultDeliveryInfo() {
     name: '산간',
     deliveryFee: 5000,
     deliveryDetail: '배송 지역이 너무멀어요',
-  });
-}
-
-async function createDefaultOrderList() {
-  const res = await OrderListRepository.getOrders(1);
-  if (res.length > 0) return;
-  const orderList = await OrderListRepository.createOrder(1, {
-    orderMemo: '지갑 거덜나네,,',
-    receiver: '아이유',
-    zipCode: '083212',
-    address: '서울 특별시 강남구',
-    subAddress: '역삼동',
-    paymentId: 1,
-  });
-  await OrderItemRepository.createOrderItem(1, orderList.id, {
-    amount: 4,
-    price: 13000,
-    discountRate: 10,
-    state: 'S',
   });
 }
 

--- a/backend/src/entity/Order.ts
+++ b/backend/src/entity/Order.ts
@@ -12,7 +12,7 @@ import { Payment } from './Payment';
 import { User } from './User';
 
 @Entity()
-export class OrderList {
+export class Order {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id: number;
 
@@ -40,12 +40,12 @@ export class OrderList {
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
 
-  @ManyToOne(() => Payment, (payment) => payment.id)
+  @ManyToOne(() => Payment)
   payment: Payment;
 
-  @ManyToOne(() => User, (user) => user.id)
+  @ManyToOne(() => User)
   user: User;
 
-  @OneToMany(() => OrderItem, (order) => order.orderList)
+  @OneToMany(() => OrderItem, (orderItem) => orderItem.order)
   orderItems: OrderItem[];
 }

--- a/backend/src/entity/OrderItem.ts
+++ b/backend/src/entity/OrderItem.ts
@@ -8,7 +8,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { Goods } from './Goods';
-import { OrderList } from './OrderList';
+import { Order } from './Order';
 
 @Entity()
 export class OrderItem {
@@ -33,11 +33,11 @@ export class OrderItem {
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
 
-  @ManyToOne(() => Goods, (goods) => goods.id)
+  @ManyToOne(() => Goods)
   @JoinColumn()
   goods: Goods;
 
-  @ManyToOne(() => OrderList, (orderList) => orderList.id)
+  @ManyToOne(() => Order, (order) => order.orderItems)
   @JoinColumn()
-  orderList: OrderList;
+  order: Order;
 }

--- a/backend/src/entity/User.ts
+++ b/backend/src/entity/User.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { Cart } from './Cart';
-import { OrderList } from './OrderList';
+import { Order } from './Order';
 import { UserAddress } from './UserAddress';
 import { Wish } from './Wish';
 

--- a/backend/src/repository/order.item.repository.ts
+++ b/backend/src/repository/order.item.repository.ts
@@ -2,33 +2,17 @@ import { getRepository } from 'typeorm';
 import { OrderItem } from '../entity/OrderItem';
 import { CreateOrderItem } from '../types/Order';
 
-async function createOrderItem(
-  goodsId: number,
-  orderListId: number,
-  orderItemBody: CreateOrderItem
-): Promise<OrderItem> {
+async function createOrderItem(goodsId: number, orderId: number, orderItemBody: CreateOrderItem): Promise<OrderItem> {
   return await getRepository(OrderItem).save({
-    ...orderItemBody,
+    amount: orderItemBody.amount,
+    price: orderItemBody.price,
+    discountRate: orderItemBody.discountRate,
+    state: orderItemBody.state,
     goods: { id: goodsId },
-    orderList: { id: orderListId },
-  });
-}
-
-async function getAllOrderItemByListId(orderListId: number): Promise<OrderItem[]> {
-  return await getRepository(OrderItem).find({ where: { orderList: orderListId } });
-}
-
-async function findOrderGoodsInfoById(orderItemId: number): Promise<OrderItem | undefined> {
-  return await getRepository(OrderItem).findOne({
-    relations: ['goods'],
-    where: {
-      id: orderItemId,
-    },
+    order: { id: orderId },
   });
 }
 
 export const OrderItemRepository = {
   createOrderItem,
-  getAllOrderItemByListId,
-  findOrderGoodsInfoById,
 };

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -1,5 +1,5 @@
 import { CreateOrder } from './../types/request/order.request';
-import { OrderList } from '../entity/OrderList';
+import { Order } from '../entity/Order';
 import { getRepository } from 'typeorm';
 import { DatabaseError } from '../errors/base.error';
 import { ORDER_LIST_DB_ERROR } from '../constants/database.error.name';
@@ -7,9 +7,9 @@ import { PaginationProps } from '../types/Pagination';
 
 const DEFAULT_ORDER_STATE = '주문완료';
 
-async function getOrders(userId: number): Promise<OrderList[]> {
+async function getOrders(userId: number): Promise<Order[]> {
   try {
-    const orderRepo = getRepository(OrderList);
+    const orderRepo = getRepository(Order);
     return await orderRepo.find({
       relations: ['payment', 'orderItems'],
       where: {
@@ -23,7 +23,7 @@ async function getOrders(userId: number): Promise<OrderList[]> {
 }
 
 async function getOwnOrderTotalCount(userId: number): Promise<number> {
-  return await getRepository(OrderList).count({
+  return await getRepository(Order).count({
     where: {
       user: {
         id: userId,
@@ -32,9 +32,9 @@ async function getOwnOrderTotalCount(userId: number): Promise<number> {
   });
 }
 
-async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId: number): Promise<OrderList[]> {
+async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId: number): Promise<Order[]> {
   try {
-    return await getRepository(OrderList).find({
+    return await getRepository(Order).find({
       relations: ['payment', 'orderItems', 'orderItems.goods'],
       where: {
         user: { id: userId },
@@ -48,10 +48,10 @@ async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId
   }
 }
 
-async function createOrder(userId: number, body: CreateOrder): Promise<OrderList> {
+async function createOrder(userId: number, body: CreateOrder): Promise<Order> {
   try {
     const { orderMemo, receiver, zipCode, address, subAddress, paymentId } = body;
-    const orderRepo = getRepository(OrderList);
+    const orderRepo = getRepository(Order);
     return await orderRepo.save({
       user: {
         id: userId,

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -41,6 +41,9 @@ async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId
       },
       skip: offset,
       take: limit,
+      order: {
+        createdAt: 'ASC',
+      },
     });
   } catch (err) {
     console.error(err);

--- a/backend/src/service/order.service.ts
+++ b/backend/src/service/order.service.ts
@@ -1,21 +1,17 @@
 import { Goods } from './../entity/Goods';
 import { OrderItem } from './../entity/OrderItem';
 import { CreateOrderBody } from './../types/request/order.request';
-import { OrderList } from '../entity/OrderList';
+import { Order } from '../entity/Order';
 import { OrderListRepository } from '../repository/order.list.repository';
 import { OrderItemRepository } from '../repository/order.item.repository';
 import { GoodsRepository } from '../repository/goods.repository';
 import { BadRequestError } from '../errors/client.error';
 import { INVALID_DATA } from '../constants/client.error.name';
 import { GetAllOrderByUserIdProps, OrderGoods } from '../types/Order';
-import { OrderListPaginationResponse, OrderListWithThumbnail } from '../types/response/order.response';
+import { OrderListPaginationResponse } from '../types/response/order.response';
 import { getTotalPage, pagination } from '../utils/pagination';
 import { PaginationProps } from '../types/Pagination';
 import { PaymentRepository } from '../repository/payment.repository';
-
-type OrderGoodsInfo = OrderItem & {
-  goods: Goods;
-};
 
 async function getOrdersPagination(
   { page, limit }: GetAllOrderByUserIdProps,
@@ -29,9 +25,8 @@ async function getOrdersPagination(
     offset: pagination.calculateOffset(newPage, limit),
     limit,
   };
-  const orders = await OrderListRepository.getOwnOrdersPagination(option, userId);
 
-  const processedOrderList = await Promise.all(orders.map((order) => processAppendingThumbnailAndTitle(order)));
+  const orders = await OrderListRepository.getOwnOrdersPagination(option, userId);
 
   return {
     meta: {
@@ -40,15 +35,15 @@ async function getOrdersPagination(
       totalPage: getTotalPage(totalCount, limit),
       totalCount,
     },
-    orderList: processedOrderList,
+    orderList: orders,
   };
 }
 
-async function createOrder(userId: number, body: CreateOrderBody): Promise<OrderList> {
+async function createOrder(userId: number, body: CreateOrderBody): Promise<Order> {
   const validateResult = await validateCreateOrder(body);
   if (!validateResult) throw new BadRequestError(INVALID_DATA);
   const { orderMemo, receiver, zipCode, address, subAddress, paymentId, goodsList } = body;
-  const orderList = await OrderListRepository.createOrder(userId, {
+  const order = await OrderListRepository.createOrder(userId, {
     orderMemo,
     receiver,
     zipCode,
@@ -56,44 +51,21 @@ async function createOrder(userId: number, body: CreateOrderBody): Promise<Order
     subAddress,
     paymentId,
   });
-  await Promise.all(goodsList.map((orderedItem) => createOrderItem(orderedItem, orderList.id)));
-  return orderList;
+  await Promise.all(goodsList.map((orderedItem) => createOrderItem(orderedItem, order.id)));
+  return order;
 }
 
-async function createOrderItem(orderedItem: OrderGoods, orderListId: number): Promise<void> {
+async function createOrderItem(orderedItem: OrderGoods, orderId: number): Promise<void> {
   const goods = await GoodsRepository.findGoodsDetailById(orderedItem.id);
-  if (!goods) throw new BadRequestError(INVALID_DATA);
+  if (!goods) throw new BadRequestError(INVALID_DATA + `(id:${orderId}는 존재하지않는 상품입니다.)`);
+
   const { price, discountRate, state } = goods;
-  await OrderItemRepository.createOrderItem(goods.id, orderListId, {
+  await OrderItemRepository.createOrderItem(goods.id, orderId, {
     price,
     discountRate,
     state,
     amount: orderedItem.amount,
   });
-}
-
-async function processAppendingThumbnailAndTitle(order: OrderList): Promise<OrderListWithThumbnail> {
-  const orderItems = await OrderItemRepository.getAllOrderItemByListId(order.id);
-  if (orderItems.length < 1) throw new BadRequestError(INVALID_DATA);
-
-  // 가장 맨 처음 탐색되는 주문 아이템이 thumbnail이 된다.
-  const orderItemInfo = await OrderItemRepository.findOrderGoodsInfoById(orderItems[0].id);
-  if (!orderItemInfo) throw new BadRequestError(INVALID_DATA);
-
-  const count = orderItems.length - 1;
-  const title = createOrderTitle(orderItemInfo.goods.title, count);
-  const thumbnailUrl = orderItemInfo.goods.thumbnailUrl;
-
-  return {
-    ...order,
-    title,
-    thumbnailUrl,
-  };
-}
-
-function createOrderTitle(title: string, count: number): string {
-  const orderTitle = count > 0 ? `${title} 외 ${count}건 주문` : `${title} 주문`;
-  return orderTitle;
 }
 
 async function validateCreateOrder(body: CreateOrderBody): Promise<boolean> {

--- a/backend/src/types/response/order.response.ts
+++ b/backend/src/types/response/order.response.ts
@@ -1,4 +1,4 @@
-import { OrderList } from '../../entity/OrderList';
+import { Order } from '../../entity/Order';
 
 export interface OrderListMetaData {
   page: number;
@@ -7,14 +7,7 @@ export interface OrderListMetaData {
   totalCount: number;
 }
 
-export interface OrderListWithThumbnail extends OrderList {
-  title: string;
-  thumbnailUrl: string;
-}
-
 export interface OrderListPaginationResponse {
   meta?: OrderListMetaData;
-  orderList?: OrderListWithThumbnail[];
+  orderList?: Order[];
 }
-
-export type GetOrderListResponse = OrderListWithThumbnail[];

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -13,6 +13,11 @@ const LIMIT_COUNT_ORDER = 4;
 const MyOrderListView = () => {
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
+  const [focusOrderId, setFocusOrderId] = useState<number>(0);
+
+  const handleClickOrder = (orderId: number) => {
+    setFocusOrderId(orderId);
+  };
 
   const fetchOrderList = async () => {
     const { result } = await OrderAPI.getOrders(currentPage, LIMIT_COUNT_ORDER);
@@ -27,16 +32,18 @@ const MyOrderListView = () => {
       alert('주문정보 불러오는데 실패했습니다. 서버오류');
     }
   }, [currentPage]);
+
   return (
     <MyOrderListViewContainer>
-      <Topic>반가워요! 주문 내역입니다.</Topic>
-      <p>주문 조회 내역 총 {orderPaginationResult?.meta.totalCount} 건</p>
+      <Topic>반가워요! 고객님의 주문 내역입니다.</Topic>
+      <OrderCountLabel>주문 조회 내역 총 {orderPaginationResult?.meta.totalCount} 건</OrderCountLabel>
       {orderPaginationResult && (
         <OrderPaginationContainer>
           <OrderCardList>
-            {orderPaginationResult?.orderList.map((order) => (
-              <OrderCard key={order.id} order={order} />
-            ))}
+            {orderPaginationResult?.orderList.map((order) => {
+              const showDetail = order.id === focusOrderId;
+              return <OrderCard key={order.id} order={order} detail={showDetail} onClick={handleClickOrder} />;
+            })}
           </OrderCardList>
 
           <Paginator
@@ -49,6 +56,11 @@ const MyOrderListView = () => {
     </MyOrderListViewContainer>
   );
 };
+
+const OrderCountLabel = styled.p`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+`;
 
 const MyOrderListViewContainer = styled.div`
   width: 900px;
@@ -65,7 +77,7 @@ const OrderCardList = styled.ul`
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  height: 500px;
+  min-height: 500px;
 `;
 
 export default MyOrderListView;

--- a/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
@@ -1,56 +1,86 @@
 import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import { Order } from '@src/types/Order';
 import { convertYYYYMMDD } from '@src/utils/dateHelper';
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import OrderItemCard from './OrderItemCard';
 
 interface Props {
   order: Order;
+  onClick: (orderId: number) => void;
+  detail?: boolean;
 }
 
-const OrderCard: React.FC<Props> = ({ order }) => {
+const OrderCard: React.FC<Props> = ({ order, onClick, detail = false }) => {
   const { orderItems } = order;
-
   return (
     <OrderCardContainer>
-      <OrderCardDateAndIdCell>
-        <OrderIdText>{order.id}</OrderIdText>
-        {convertYYYYMMDD(new Date(order.createdAt))}
-      </OrderCardDateAndIdCell>
-      <OrderCardProductInfo>
-        {orderItems.length > 0 ? (
-          <>
-            <ThumbnailImg src={orderItems[0].goods.thumbnailUrl} />
-            <OrderCardProductInfoTitle>{orderItems[0].goods.title}</OrderCardProductInfoTitle>
-          </>
-        ) : (
-          <h1>대표 상품이 없습니다.</h1>
-        )}
-      </OrderCardProductInfo>
-      <OrderCardStateInfo>
-        <OrderStateText>
-          <HighlightedText fontSize={'10px'}>{order.state}</HighlightedText>
-        </OrderStateText>
-      </OrderCardStateInfo>
-      <OrderCardDeliveryInfo>
-        <div>{order.address}</div>
-        <div>{order.subAddress}</div>
-      </OrderCardDeliveryInfo>
-      <OrderControlContainer>
-        <button>자세히 보기</button>
-      </OrderControlContainer>
+      <MainContent onClick={() => onClick(order.id)}>
+        <OrderCardDateAndIdCell>
+          <OrderIdText>{order.id}</OrderIdText>
+          {convertYYYYMMDD(new Date(order.createdAt))}
+        </OrderCardDateAndIdCell>
+        <OrderCardProductInfo>
+          {orderItems.length > 0 ? (
+            <>
+              <ThumbnailImg src={orderItems[0].goods.thumbnailUrl} />
+              <OrderCardProductInfoTitle>
+                <span>{orderItems[0].goods.title}</span>
+                {orderItems.length > 1 && <span> 외 {orderItems.length - 1} 개의 상품</span>}
+              </OrderCardProductInfoTitle>
+            </>
+          ) : (
+            <h1>대표 상품이 없습니다.</h1> // 데이터 무결성 문제.
+          )}
+        </OrderCardProductInfo>
+        <OrderCardStateInfo>
+          <OrderStateText>
+            <HighlightedText fontSize={'10px'}>{order.state}</HighlightedText>
+          </OrderStateText>
+        </OrderCardStateInfo>
+        <OrderCardDeliveryInfo>
+          <div>{order.address}</div>
+          <div>{order.subAddress}</div>
+        </OrderCardDeliveryInfo>
+      </MainContent>
+
+      {detail && (
+        <DetailContent>
+          {orderItems.map((orderItem) => (
+            <OrderItemCard key={orderItem.id} orderItem={orderItem} />
+          ))}
+        </DetailContent>
+      )}
     </OrderCardContainer>
   );
 };
 
-const OrderCardContainer = styled.li`
+const MainContent = styled.div`
   display: grid;
-  grid-template-columns: 1fr 3fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 3fr 1fr 1fr;
   grid-template-rows: 1fr;
-  border-bottom: 1px solid black;
   height: 120px;
   width: 100%;
   padding: 10px;
+  cursor: pointer;
+`;
+
+const DetailContent = styled.div`
+  display: flex;
+  padding-left: 10px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  overflow: scroll;
+`;
+
+interface OrderCardContainer {
+  theme: {
+    line: string;
+  };
+}
+const OrderCardContainer = styled.li<OrderCardContainer>`
+  width: 100%;
+  border: 1px solid ${(props) => props.theme.line};
 `;
 
 const OrderCardDateAndIdCell = styled.div`

--- a/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const OrderCard: React.FC<Props> = ({ order }) => {
   const { orderItems } = order;
-  console.log(order);
+
   return (
     <OrderCardContainer>
       <OrderCardDateAndIdCell>
@@ -18,8 +18,14 @@ const OrderCard: React.FC<Props> = ({ order }) => {
         {convertYYYYMMDD(new Date(order.createdAt))}
       </OrderCardDateAndIdCell>
       <OrderCardProductInfo>
-        {/* <ThumbnailImg src={mainOrderItem.goods.thumbnailUrl} />
-        <OrderCardProductInfoTitle>{mainOrderItem.goods.title}</OrderCardProductInfoTitle> */}
+        {orderItems.length > 0 ? (
+          <>
+            <ThumbnailImg src={orderItems[0].goods.thumbnailUrl} />
+            <OrderCardProductInfoTitle>{orderItems[0].goods.title}</OrderCardProductInfoTitle>
+          </>
+        ) : (
+          <h1>대표 상품이 없습니다.</h1>
+        )}
       </OrderCardProductInfo>
       <OrderCardStateInfo>
         <OrderStateText>

--- a/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/OrderCard.tsx
@@ -9,6 +9,8 @@ interface Props {
 }
 
 const OrderCard: React.FC<Props> = ({ order }) => {
+  const { orderItems } = order;
+  console.log(order);
   return (
     <OrderCardContainer>
       <OrderCardDateAndIdCell>
@@ -16,8 +18,8 @@ const OrderCard: React.FC<Props> = ({ order }) => {
         {convertYYYYMMDD(new Date(order.createdAt))}
       </OrderCardDateAndIdCell>
       <OrderCardProductInfo>
-        <ThumbnailImg src={order.thumbnailUrl} />
-        <OrderCardProductInfoTitle>{order.title}</OrderCardProductInfoTitle>
+        {/* <ThumbnailImg src={mainOrderItem.goods.thumbnailUrl} />
+        <OrderCardProductInfoTitle>{mainOrderItem.goods.title}</OrderCardProductInfoTitle> */}
       </OrderCardProductInfo>
       <OrderCardStateInfo>
         <OrderStateText>

--- a/frontend/client/src/pages/MyPage/MyOrderListView/OrderItemCard.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/OrderItemCard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { OrderItem } from '@src/types/Order';
+import { usePushHistory } from '@src/lib/CustomRouter';
+import GoodsAmount from '@src/pages/GoodsDetail/GoodsInteractive/GoodsAmount/GoodsAmount';
+
+interface OrderItemCardProps {
+  orderItem: OrderItem;
+}
+
+const OrderItemCard: React.FC<OrderItemCardProps> = ({ orderItem }) => {
+  const {
+    amount,
+    goods: { id: goodsId, title, thumbnailUrl },
+  } = orderItem;
+
+  const push = usePushHistory();
+  const handleMoveDetailGoodsPage = () => {
+    push('/detail/' + goodsId);
+  };
+
+  return (
+    <OrderItemCardContainer onClick={handleMoveDetailGoodsPage}>
+      <OrderItemCardThumbnail src={thumbnailUrl} />
+      <OrderItemCardInfo>
+        {truncateString(title, 20)}
+        {amount > 1 && ` x ${amount}`}
+      </OrderItemCardInfo>
+    </OrderItemCardContainer>
+  );
+};
+
+const truncateString = (text: string, length: number) => (text.length > length ? text.slice(0, length) + '...' : text);
+
+interface OrderItemCardContainerProps {
+  theme: {
+    primary: string;
+  };
+}
+const OrderItemCardContainer = styled.div<OrderItemCardContainerProps>`
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  &:hover {
+    border: 1px solid ${(props) => props.theme.primary};
+  }
+`;
+
+const OrderItemCardThumbnail = styled.img`
+  width: 50px;
+  height: 50px;
+
+  object-fit: contain;
+`;
+
+const OrderItemCardInfo = styled.p`
+  margin-top: 5px;
+`;
+
+export default OrderItemCard;

--- a/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
@@ -1,5 +1,6 @@
 import { getMyWishGoods } from '@src/apis/goodsAPI';
 import GoodsSection from '@src/components/GoodsSection/GoodsSection';
+import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import Paginator from '@src/components/Paginator/Paginator';
 import Topic from '@src/components/Topic/Topic';
 import { GoodsPaginationResult } from '@src/types/Goods';
@@ -30,7 +31,7 @@ const MyWishListView = () => {
   return (
     <MyWishListViewContainer>
       <Topic>관심 상품 리스트</Topic>
-      {goodsPaginationResult && (
+      {goodsPaginationResult ? (
         <>
           <GoodsSection goodsList={goodsPaginationResult.goodsList} itemBoxSize='small' />
           <Paginator
@@ -38,6 +39,10 @@ const MyWishListView = () => {
             currentPage={goodsPaginationResult.meta.page}
             setPage={setCurrentPage}
           />
+        </>
+      ) : (
+        <>
+          <HighlightedText> 찜 리스트가 비어있습니다! </HighlightedText>
         </>
       )}
     </MyWishListViewContainer>

--- a/frontend/client/src/types/Order.ts
+++ b/frontend/client/src/types/Order.ts
@@ -19,8 +19,6 @@ export interface Order {
   receiver: string;
   state: string;
   subAddress: string;
-  thumbnailUrl: string;
-  title: string;
   payment: Payment;
   zipCode: string;
   updatedAt: string;


### PR DESCRIPTION
## :bookmark_tabs: 제목

Order 관련 API들을 리팩토링(OrderList 를 Order로 엔티티 이름을 수정했습니다.)  모두 데이터베이스를 한번 비워야할 듯합니다. 이미 데이터가 있다면 마이그레이션을 자동으로 할 수 없습니다. (테이블 이름이 바뀌어서 제약조건변경이 필요)

MyPage 주문 내역에서 OrderItem들 보여주도록 수정.

<img width="1081" alt="스크린샷 2021-08-22 오후 11 23 31" src="https://user-images.githubusercontent.com/20085849/130358572-0706cd28-121a-4252-a3f4-0a24eb212ce7.png">


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] `OrderList` => `Order` 엔티티 이름 변경. 의미상 주문하나를 의미하기 떄문에 변경했습니다.
- [x] Order를 조회하는 API에서 대표 상품에 대한 정보를 붙여주는 작업을 제거 (클라이언트에서 하는 것이 더 간단해짐)
- [x] My Page Order 조회 화면 수정
  
## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Entity의 참조 컬럼들의 `@ManyToOne`의 설정을 제대로하고 있는지 체크해봐야할 듯합니다.

예를 들어 아래의 Goods Entity의 `(deliveryInfo) => deliveryInfo.id` 설정을 마다 deliveryInfo.goodsList 이런식으로 나타내거나
deliveryInfo에서 Goods관련 관계가 필요없는 경우, 제거하는게 맞아보입니다. 해당 설정의 정확한 효력은 문서를 더 찾아봐야할 듯합니다.

<img width="713" alt="스크린샷 2021-08-22 오후 11 20 39" src="https://user-images.githubusercontent.com/20085849/130358506-d9bf079f-842f-47dd-b5c3-db0046b0486c.png">
 
