### PR TITLE
[feature/151] 대시보드- 상품 카테고리 비율 차트, TOP 상품 컴포넌트 개발 (Client-로그인,로그아웃 메인 UX 개선)

### DIFF
--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -19,7 +19,13 @@ async function getAllCategory(req: Request, res: Response) {
   });
 }
 
+async function getParentCategoryCount(req: Request, res: Response) {
+  const result = await CategoryService.getParentCategoryCount();
+  res.status(200).json({ result });
+}
+
 export default {
   createCategory,
   getAllCategory,
+  getParentCategoryCount,
 };

--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -99,19 +99,23 @@ async function getAllGoodsForAdmin(req: Request, res: Response) {
 async function getMainGoodsListMap(req: Request, res: Response) {
   const userId = req.session.userId;
   const result = await GoodsService.getMainGoodsListMap(userId);
-  return res.status(200).json({ result });
+  res.status(200).json({ result });
 }
 
 async function getGoodsStockById(req: Request, res: Response) {
   const goodsId = Number(req.params.id);
   const result = await GoodsService.getGoodsStockById(goodsId);
-  return res.status(200).json({ result });
+  res.status(200).json({ result });
 }
 
 async function getGoodsImgById(req: Request, res: Response) {
   const goodsId = Number(req.params.id);
   const result = await GoodsService.getGoodsImgById(goodsId);
   return res.status(200).json({ result });
+
+async function getBestGoodsForDashboard(req: Request, res: Response) {
+  const result = await GoodsService.getBestSellingGoodsForDashboard();
+  res.status(200).json({ result });
 }
 
 export const GoodsController = {
@@ -123,4 +127,5 @@ export const GoodsController = {
   getAllGoodsForClient,
   getAllGoodsForAdmin,
   getGoodsImgById,
+  getBestGoodsForDashboard,
 };

--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -112,6 +112,7 @@ async function getGoodsImgById(req: Request, res: Response) {
   const goodsId = Number(req.params.id);
   const result = await GoodsService.getGoodsImgById(goodsId);
   return res.status(200).json({ result });
+}
 
 async function getBestGoodsForDashboard(req: Request, res: Response) {
   const result = await GoodsService.getBestSellingGoodsForDashboard();

--- a/backend/src/repository/category.repository.ts
+++ b/backend/src/repository/category.repository.ts
@@ -48,9 +48,33 @@ async function getAllCategories(): Promise<Category[]> {
   }
 }
 
+async function getParentCategories(): Promise<Category[]> {
+  try {
+    return getRepository(Category).find({
+      where: {
+        parent: null,
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(CATEGORY_DB_ERROR);
+  }
+}
+
+async function getCategoryCountByParentId(parentId: number):Promise<number> {
+  try {
+    return getRepository(Category).count({ where: { parent: parentId } });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(CATEGORY_DB_ERROR);
+  }
+}
+
 export const CategoryRepository = {
   createCategory,
   createSubCategory,
   getCategoryByName,
   getAllCategories,
+  getParentCategories,
+  getCategoryCountByParentId,
 };

--- a/backend/src/repository/goods.repository.ts
+++ b/backend/src/repository/goods.repository.ts
@@ -151,6 +151,14 @@ async function findStockById(goodsId: number): Promise<number> {
   return goods?.stock ?? 0;
 }
 
+async function findBestSellingGoods(limit: number): Promise<Goods[]> {
+  return getRepository(Goods).find({
+    order: {
+      countOfSell: 'DESC',
+    },
+    take: limit,
+  });
+}
 export const GoodsRepository = {
   findGoodsById,
   findGoodsDetailById,
@@ -158,6 +166,7 @@ export const GoodsRepository = {
   findAllWishByUserId,
   findTotalCountByOption,
   findSellCountAverage,
-  searchGoodsFromKeyword,
   findStockById,
+  findBestSellingGoods,
+  searchGoodsFromKeyword,
 };

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -6,5 +6,6 @@ const router = express.Router();
 
 router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
+router.get('/admin/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
 
 export default router;

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -6,6 +6,6 @@ const router = express.Router();
 
 router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
-router.get('/admin/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
+router.get('/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
 
 export default router;

--- a/backend/src/router/goods.router.ts
+++ b/backend/src/router/goods.router.ts
@@ -32,4 +32,7 @@ router.get('/:id/stock', checkNumberInParams, wrapAsync(GoodsController.getGoods
 router.get('/:id/img', checkNumberInParams, wrapAsync(GoodsController.getGoodsImgById));
 router.get('/:id', checkNumberInParams, wrapAsync(GoodsController.getGoodsDetail));
 
+// TODO: dashboard admin?
+router.get('/dashboard/best', wrapAsync(GoodsController.getBestGoodsForDashboard));
+
 export default router;

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -1,5 +1,5 @@
 import { Category } from '../entity/Category';
-import { CategoryResponse } from '../types/response/category.response';
+import { CategoryCountResponse, CategoryResponse } from '../types/response/category.response';
 import { CategoryRepository } from '../repository/category.repository';
 
 async function createCategory(name: string, parentId?: number): Promise<Category> {
@@ -41,7 +41,25 @@ async function getAllCategory(): Promise<CategoryResponse[]> {
   return Array.from(categoryMap.entries()).map(([_, value]) => value);
 }
 
+async function getParentCategoryCount(): Promise<CategoryCountResponse> {
+  const categoryCountList: CategoryCountResponse = [];
+  const parentCategories = await CategoryRepository.getParentCategories();
+  await Promise.all(
+    parentCategories.map(async (category) => await pushCategoryCountToList(category, categoryCountList))
+  );
+  return categoryCountList;
+}
+
+async function pushCategoryCountToList(category: Category, categoryCountList: CategoryCountResponse): Promise<void> {
+  const count = await CategoryRepository.getCategoryCountByParentId(category.id);
+  categoryCountList.push({
+    name: category.name,
+    value: count,
+  });
+}
+
 export default {
   createCategory,
   getAllCategory,
+  getParentCategoryCount,
 };

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -41,6 +41,7 @@ const INVALID_DISCOUNT_RATE = '할인율은 0~99% 범위 내에서 가능합니�
 const INVALID_DELIVERY_INFO = '해당 배송 정보는 없는 정보입니다.';
 const MIN_DISCOUNT_RATE = 0;
 const MAX_DISCOUNT_RATE = 99;
+const BEST_SELLING_GOODS_LIMIT = 5;
 
 async function createGoods(body: CreateGoodsBody, uploadFileUrls: string[]): Promise<Goods> {
   await checkValidateCreateGoods(body);
@@ -288,6 +289,10 @@ async function getMainGoodsListMap(userId?: number): Promise<{
   };
 }
 
+async function getBestSellingGoodsForDashboard(): Promise<Goods[]> {
+  return GoodsRepository.findBestSellingGoods(BEST_SELLING_GOODS_LIMIT);
+}
+
 async function getGoodsStockById(goodsId: number): Promise<number> {
   return await GoodsRepository.findStockById(goodsId);
 }
@@ -346,4 +351,5 @@ export const GoodsService = {
   getMainGoodsListMap,
   getGoodsStockById,
   getGoodsImgById,
+  getBestSellingGoodsForDashboard,
 };

--- a/backend/src/types/response/category.response.ts
+++ b/backend/src/types/response/category.response.ts
@@ -1,3 +1,10 @@
+type CategoryCount = {
+  name: string;
+  value: number;
+};
+
+export type CategoryCountResponse = CategoryCount[];
+
 export type CategoryResponse = {
   id: number;
   name: string;

--- a/frontend/admin/package-lock.json
+++ b/frontend/admin/package-lock.json
@@ -1199,7 +1199,6 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -2160,6 +2159,32 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/d3-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
+    },
+    "@types/d3-scale": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
+      "requires": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "@types/d3-shape": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "requires": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "@types/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
+    },
     "@types/eslint": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -2344,6 +2369,11 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/resize-observer-browser": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz",
+      "integrity": "sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg=="
     },
     "@types/scheduler": {
       "version": "0.16.2",
@@ -4067,6 +4097,11 @@
         }
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
+    },
     "css-what": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
@@ -4178,6 +4213,73 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
       "dev": true
     },
+    "d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "requires": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -4209,6 +4311,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -4482,6 +4589,14 @@
         "utila": "~0.4"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-serializer": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
@@ -4745,8 +4860,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -4979,6 +5093,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-equals": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.3.tgz",
+      "integrity": "sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5857,6 +5976,11 @@
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
       }
+    },
+    "internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -8195,6 +8319,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -8917,6 +9046,11 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -9452,6 +9586,16 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9506,6 +9650,14 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -9571,6 +9723,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-resize-detector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.6.tgz",
+      "integrity": "sha512-/6RZlul1yePSoYJxWxmmgjO320moeLC/khrwpEVIL+D2EjLKhqOwzFv+H8laMbImVj7Zu4FlMa0oA7au3/ChjQ==",
+      "requires": {
+        "@types/resize-observer-browser": "^0.1.6",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
     "react-slick": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.28.1.tgz",
@@ -9581,6 +9749,27 @@
         "json2mq": "^0.2.0",
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-smooth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.0.tgz",
+      "integrity": "sha512-wK4dBBR6P21otowgMT9toZk+GngMplGS1O5gk+2WSiHEXIrQgDvhR5IIlT74Vtu//qpTcipkgo21dD7a7AUNxw==",
+      "requires": {
+        "fast-equals": "^2.0.0",
+        "raf": "^3.4.0",
+        "react-transition-group": "2.9.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "readable-stream": {
@@ -9607,6 +9796,41 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "recharts": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.1.tgz",
+      "integrity": "sha512-slV1RDbLPxyA3/63bjvtdrTXOuFnO6cdh/XlEu1XaM/PigPwBK2NZrVarjcirlAd7fkUzFIgKQjCxC+Hk1ymGQ==",
+      "requires": {
+        "@types/d3-scale": "^3.0.0",
+        "@types/d3-shape": "^2.0.0",
+        "classnames": "^2.2.5",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-shape": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "16.10.2",
+        "react-resize-detector": "^6.6.3",
+        "react-smooth": "^2.0.0",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.10.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+          "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+        }
+      }
+    },
+    "recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "rechoir": {
@@ -9636,6 +9860,22 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
+      }
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -9654,8 +9894,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -10581,16 +10820,6 @@
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
       }
-    },
-    "styled-normalize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-8.0.7.tgz",
-      "integrity": "sha512-qQV4O7B9g7ZUnStCwGde7Dc/mcFF/pz0Ha/LL7+j/r6uopf6kJCmmR7jCPQMCBrDkYiQ4xvw1hUoceVJkdaMuQ=="
-    },
-    "styled-reset": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.3.4.tgz",
-      "integrity": "sha512-1UmkWmRwSPfzolKleyPjbZdBqkxSXv5ImqTP5WeSjWk0Z7IvEzsrYhrqinZfCg10eM1P6BEtFly8+puQJnN/0A=="
     },
     "stylehacks": {
       "version": "5.0.1",

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -20,9 +20,10 @@
     "react-dom": "17.0.2",
     "react-icons": "4.2.0",
     "react-slick": "0.28.1",
+    "recharts": "^2.1.1",
     "recoil": "0.4.0",
-    "styled-components": "5.3.0",
-    "slick-carousel": "1.8.1"
+    "slick-carousel": "1.8.1",
+    "styled-components": "5.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.14.5",

--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -12,6 +12,9 @@ export default function App() {
     <>
       <Router>
         <Header />
+        <Route path='/'>
+          <Main />
+        </Route>
         <Routes>
           <Route path='/admin'>
             <Routes>

--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -12,9 +12,6 @@ export default function App() {
     <>
       <Router>
         <Header />
-        <Route path='/'>
-          <Main />
-        </Route>
         <Routes>
           <Route path='/admin'>
             <Routes>

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -1,4 +1,5 @@
 import { Category } from '@src/types/Category';
+import { PieChartData } from '@src/types/Chart';
 import { APIResponse, checkedFetch } from './base';
 interface CategoryResponse {
   categories: Category[];
@@ -8,9 +9,20 @@ const getAllCategory = async (): Promise<APIResponse<CategoryResponse>> => {
     method: 'GET',
     credentials: 'include',
   });
-  return await res.json();
+  return res.json();
 };
 
-export const CategoryAPI = {
-  getAllCategory,
+const getParentCategoryCount = async (): Promise<APIResponse<PieChartData>> => {
+  const res = await checkedFetch(`/api/category/admin/dashboard`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return res.json();
 };
+
+const CategoryAPI = {
+  getAllCategory,
+  getParentCategoryCount,
+};
+
+export default CategoryAPI;

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -13,7 +13,7 @@ const getAllCategory = async (): Promise<APIResponse<CategoryResponse>> => {
 };
 
 const getParentCategoryCount = async (): Promise<APIResponse<PieChartData>> => {
-  const res = await checkedFetch(`/api/category/admin/dashboard`, {
+  const res = await checkedFetch(`/api/category/dashboard`, {
     method: 'GET',
     credentials: 'include',
   });

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -1,3 +1,4 @@
+import { GoodsItem } from './../types/Goods';
 import { APIResponse, checkedFetch } from '@src/apis/base';
 import { CreatedGoods, GetGoodsByOptionProps, GoodsPaginationResult } from '@src/types/Goods';
 import { GoodsImg } from '@src/types/GoodsImg';
@@ -50,9 +51,18 @@ const getGoodsImgById = async (goodsId: number): Promise<APIResponse<GoodsImg[]>
   return await res.json();
 };
 
+const getBestSellingGoodsForDashboard = async (): Promise<APIResponse<GoodsItem[]>> => {
+  const res = await checkedFetch(`/api/goods/dashboard/best`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return await res.json();
+};
+
 export const GoodsAPI = {
   createGoods,
   updateGoods,
   getGoodsByOption,
   getGoodsImgById,
+  getBestSellingGoodsForDashboard,
 };

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -1,0 +1,60 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import { theme } from '@src/theme/theme';
+import React from 'react';
+import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
+
+const CategoryPieChart = () => {
+  const mock = [
+    { name: '잡화', value: 40 },
+    { name: '문구', value: 30 },
+    { name: '생필품', value: 15 },
+    { name: '에디션', value: 15 },
+  ];
+  const COLORS = [
+    'rgba(255, 99, 132, 0.6)',
+    'rgba(54, 162, 235, 0.6)',
+    'rgba(255, 206, 86, 0.6)',
+    'rgba(75, 192, 192, 0.6)',
+    'rgba(153, 102, 255, 0.6)',
+    'rgba(255, 159, 64, 0.6)',
+  ];
+  return (
+    <PieChartContainer>
+      <PieChartTitle color={theme.greenColor}>카테고리 비율</PieChartTitle>
+      <ResponsiveContainer width='100%' height='105%'>
+        <PieChart>
+          <Pie
+            data={mock}
+            cx='50%'
+            cy='50%'
+            labelLine={false}
+            label
+            outerRadius={90}
+            innerRadius={30}
+            fill='#8884d8'
+            dataKey='value'
+            cursor='pointer'
+          >
+            {mock.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </PieChartContainer>
+  );
+};
+
+const PieChartContainer = styled('div')`
+  padding: 16px;
+  width: 25%;
+  height: 25%;
+`;
+
+const PieChartTitle = styled('span')<{ color: string }>`
+  color: ${(props) => props.color};
+  font-weight: 700;
+`;
+
+export default CategoryPieChart;

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -5,10 +5,10 @@ import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
 
 const CategoryPieChart = () => {
   const mock = [
-    { name: '잡화', value: 40 },
-    { name: '문구', value: 30 },
-    { name: '생필품', value: 15 },
-    { name: '에디션', value: 15 },
+    { name: '잡화', value: 400 },
+    { name: '문구', value: 300 },
+    { name: '생필품', value: 125 },
+    { name: '에디션', value: 135 },
   ];
   const COLORS = [
     'rgba(255, 99, 132, 0.6)',
@@ -21,17 +21,18 @@ const CategoryPieChart = () => {
   return (
     <PieChartContainer>
       <PieChartTitle color={theme.greenColor}>카테고리 비율</PieChartTitle>
-      <ResponsiveContainer width='100%' height='105%'>
+      <ResponsiveContainer width='100%' height='100%'>
         <PieChart>
           <Pie
             data={mock}
             cx='50%'
             cy='50%'
+            isAnimationActive={true}
+            animationDuration={600}
             labelLine={false}
-            label
-            outerRadius={90}
-            innerRadius={30}
-            fill='#8884d8'
+            label={(entry) => entry.name}
+            outerRadius={120}
+            innerRadius={60}
             dataKey='value'
             cursor='pointer'
           >
@@ -48,11 +49,15 @@ const CategoryPieChart = () => {
 
 const PieChartContainer = styled('div')`
   padding: 16px;
-  width: 25%;
-  height: 25%;
+  width: 50%;
+  height: 100%;
+  background-color: whitesmoke;
+  border-radius: 16px;
+  margin-right: 16px;
 `;
 
 const PieChartTitle = styled('span')<{ color: string }>`
+  position: absolute;
   color: ${(props) => props.color};
   font-weight: 700;
 `;

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -1,30 +1,39 @@
+import CategoryAPI from '@src/apis/categoryAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import { theme } from '@src/theme/theme';
-import React from 'react';
+import { PieChartData } from '@src/types/Chart';
+import React, { useEffect, useState } from 'react';
 import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
 
 const CategoryPieChart = () => {
-  const mock = [
-    { name: '잡화', value: 400 },
-    { name: '문구', value: 300 },
-    { name: '생필품', value: 125 },
-    { name: '에디션', value: 135 },
-  ];
+  const [chartData, setChartData] = useState<PieChartData>([]);
   const COLORS = [
-    'rgba(255, 99, 132, 0.6)',
-    'rgba(54, 162, 235, 0.6)',
-    'rgba(255, 206, 86, 0.6)',
-    'rgba(75, 192, 192, 0.6)',
-    'rgba(153, 102, 255, 0.6)',
-    'rgba(255, 159, 64, 0.6)',
+    theme.ChartColorRed,
+    theme.ChartColorBlue,
+    theme.ChartColorYellow,
+    theme.ChartColorGreen,
+    theme.ChartColorPurple,
+    theme.ChartColorOrange,
   ];
+
+  useEffect(() => {
+    async function fetchChartData() {
+      try {
+        const { result } = await CategoryAPI.getParentCategoryCount();
+        setChartData(result);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchChartData();
+  }, []);
   return (
     <PieChartContainer>
       <PieChartTitle color={theme.greenColor}>카테고리 비율</PieChartTitle>
       <ResponsiveContainer width='100%' height='100%'>
         <PieChart>
           <Pie
-            data={mock}
+            data={chartData}
             cx='50%'
             cy='50%'
             isAnimationActive={true}
@@ -36,7 +45,7 @@ const CategoryPieChart = () => {
             dataKey='value'
             cursor='pointer'
           >
-            {mock.map((entry, index) => (
+            {chartData.map((entry, index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
             ))}
           </Pie>

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -1,9 +1,9 @@
 import CategoryAPI from '@src/apis/categoryAPI';
-import { styled } from '@src/lib/CustomStyledComponent';
 import { theme } from '@src/theme/theme';
 import { PieChartData } from '@src/types/Chart';
 import React, { useEffect, useState } from 'react';
 import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
+import styled from 'styled-components';
 
 const CategoryPieChart = () => {
   const [chartData, setChartData] = useState<PieChartData>([]);
@@ -27,6 +27,7 @@ const CategoryPieChart = () => {
     }
     fetchChartData();
   }, []);
+
   return (
     <PieChartContainer>
       <PieChartTitle color={theme.greenColor}>카테고리 비율</PieChartTitle>
@@ -36,8 +37,7 @@ const CategoryPieChart = () => {
             data={chartData}
             cx='50%'
             cy='50%'
-            isAnimationActive={true}
-            animationDuration={600}
+            isAnimationActive={false}
             labelLine={false}
             label={(entry) => entry.name}
             outerRadius={120}
@@ -56,7 +56,7 @@ const CategoryPieChart = () => {
   );
 };
 
-const PieChartContainer = styled('div')`
+const PieChartContainer = styled.div`
   padding: 16px;
   width: 50%;
   height: 100%;
@@ -65,7 +65,7 @@ const PieChartContainer = styled('div')`
   margin-right: 16px;
 `;
 
-const PieChartTitle = styled('span')<{ color: string }>`
+const PieChartTitle = styled.span<{ color: string }>`
   position: absolute;
   color: ${(props) => props.color};
   font-weight: 700;

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { styled } from '@src/lib/CustomStyledComponent';
 import TopSellingGoodsList from '@src/pages/Main/TopSellingGoodsList/TopSellingGoodsList';
+import CategoryPieChart from '@src/pages/Main/CategoryPieChart/CategoryPieChart';
 
 const Main = () => {
   return (
     <MainContainer>
+      <CategoryPieChart />
       <TopSellingGoodsList />
     </MainContainer>
   );

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -1,23 +1,18 @@
 import React, { useState } from 'react';
 import { styled } from '@src/lib/CustomStyledComponent';
-import GoodsUploadModal from '@src/portal/GoodsUploadModal/GoodsUploadModal';
+import TopSellingGoodsList from '@src/pages/Main/TopSellingGoodsList/TopSellingGoodsList';
 
 const Main = () => {
-  const [openUploadModal, setOpenUploadModal] = useState(false);
   return (
     <MainContainer>
-      <button
-        onClick={() => {
-          setOpenUploadModal(true);
-        }}
-      >
-        제품 등록
-      </button>
-      {openUploadModal && <GoodsUploadModal onClose={() => setOpenUploadModal(false)} />}
+      <TopSellingGoodsList />
     </MainContainer>
   );
 };
 
-const MainContainer = styled('div')``;
+const MainContainer = styled('div')`
+  position: relative;
+  width: 100%;
+`;
 
 export default Main;

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -6,15 +6,40 @@ import CategoryPieChart from '@src/pages/Main/CategoryPieChart/CategoryPieChart'
 const Main = () => {
   return (
     <MainContainer>
-      <CategoryPieChart />
-      <TopSellingGoodsList />
+      <LeftContainer>
+        <LeftTopContainer>
+          <CategoryPieChart />
+          <TopSellingGoodsList />
+        </LeftTopContainer>
+        <div>왼쪽 하단</div>
+      </LeftContainer>
+      <RightContainer>오른쪽 한열</RightContainer>
     </MainContainer>
   );
 };
 
 const MainContainer = styled('div')`
   position: relative;
+  display: flex;
   width: 100%;
+  min-width: 1280px;
+  padding: 32px;
 `;
+
+const LeftContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 60%;
+  height: 50%;
+`;
+
+const LeftTopContainer = styled('div')`
+  display: flex;
+  width: 100%;
+  height: 100%;
+`;
+
+const RightContainer = styled('div')``;
 
 export default Main;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -29,7 +29,7 @@ const TopSellingGoodsContainer = styled('div')`
   position: relative;
   display: flex;
   align-items: center;
-  height: 16%;
+  height: 15%;
   width: 100%;
   margin-bottom: 16px;
 `;
@@ -38,6 +38,7 @@ const TopSellingGoodsImage = styled('img')`
   height: 100%;
   margin-right: 16px;
   object-fit: cover;
+  border-radius: 8px;
 `;
 
 const TopSellingGoodsTitle = styled('p')`

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -9,9 +9,10 @@ interface Props {
     title: string;
     countOfSell: number;
   };
+  rank: number;
 }
 
-const TopSellingGoods: React.FC<Props> = ({ item }) => {
+const TopSellingGoods: React.FC<Props> = ({ item, rank }) => {
   return (
     <TopSellingGoodsContainer>
       <TopSellingGoodsImage src={item.thumbnailUrl} />
@@ -19,14 +20,16 @@ const TopSellingGoods: React.FC<Props> = ({ item }) => {
       <SellingGoodsCountContainer bgcolor={theme.greenColor}>
         <TopSellingGoodsCount> {convertCountOfSell(item.countOfSell)}</TopSellingGoodsCount>
       </SellingGoodsCountContainer>
+      <TopSellingRank bgcolor={theme.greenColor}>{rank + 1}</TopSellingRank>
     </TopSellingGoodsContainer>
   );
 };
 
 const TopSellingGoodsContainer = styled('div')`
+  position: relative;
   display: flex;
   align-items: center;
-  height: 20%;
+  height: 16%;
   width: 100%;
   margin-bottom: 16px;
 `;
@@ -51,8 +54,20 @@ const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`
   background-color: ${(props) => props.bgcolor};
   border-radius: 12px;
 `;
+
 const TopSellingGoodsCount = styled('span')`
   color: #fff;
+`;
+
+const TopSellingRank = styled('div')<{ bgcolor: string }>`
+  position: absolute;
+  top: -5px;
+  left: -5px;
+  text-align: center;
+  background-color: ${(props) => props.bgcolor};
+  color: #fff;
+  width: 1.1em;
+  border-radius: 50%;
 `;
 
 export default TopSellingGoods;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import { theme } from '@src/theme/theme';
+import convertCountOfSell from '@src/utils/convertCountOfSell';
+import React from 'react';
+
+interface Props {
+  item: {
+    thumbnailUrl: string;
+    title: string;
+    countOfSell: number;
+  };
+}
+
+const TopSellingGoods: React.FC<Props> = ({ item }) => {
+  return (
+    <TopSellingGoodsContainer>
+      <TopSellingGoodsImage src={item.thumbnailUrl} />
+      <TopSellingGoodsTitle>{item.title}</TopSellingGoodsTitle>
+      <SellingGoodsCountContainer bgcolor={theme.greenColor}>
+        <TopSellingGoodsCount> {convertCountOfSell(item.countOfSell)}</TopSellingGoodsCount>
+      </SellingGoodsCountContainer>
+    </TopSellingGoodsContainer>
+  );
+};
+
+const TopSellingGoodsContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 16px;
+`;
+const TopSellingGoodsImage = styled('img')`
+  width: 25%;
+  margin-right: 16px;
+`;
+
+const TopSellingGoodsTitle = styled('p')`
+  width: 60%;
+  margin-right: 16px;
+`;
+
+const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`
+  padding: 0.5em;
+  background-color: ${(props) => props.bgcolor};
+  border-radius: 16px;
+`;
+const TopSellingGoodsCount = styled('span')`
+  color: #fff;
+`;
+
+export default TopSellingGoods;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -37,6 +37,10 @@ const TopSellingGoodsImage = styled('img')`
 const TopSellingGoodsTitle = styled('p')`
   width: 60%;
   margin-right: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: start;
 `;
 
 const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -26,12 +26,15 @@ const TopSellingGoods: React.FC<Props> = ({ item }) => {
 const TopSellingGoodsContainer = styled('div')`
   display: flex;
   align-items: center;
+  height: 20%;
   width: 100%;
   margin-bottom: 16px;
 `;
 const TopSellingGoodsImage = styled('img')`
   width: 25%;
+  height: 100%;
   margin-right: 16px;
+  object-fit: cover;
 `;
 
 const TopSellingGoodsTitle = styled('p')`
@@ -46,7 +49,7 @@ const TopSellingGoodsTitle = styled('p')`
 const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`
   padding: 0.5em;
   background-color: ${(props) => props.bgcolor};
-  border-radius: 16px;
+  border-radius: 12px;
 `;
 const TopSellingGoodsCount = styled('span')`
   color: #fff;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import TopSellingGoods from '@src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods';
+import { theme } from '@src/theme/theme';
+import React from 'react';
+
+const TopSellingGoodsList = () => {
+  const mock = [
+    {
+      thumbnailUrl:
+        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
+      title: 'dummy1',
+      countOfSell: 1330,
+    },
+    {
+      thumbnailUrl:
+        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
+      title: 'dummy2',
+      countOfSell: 25500,
+    },
+    {
+      thumbnailUrl:
+        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
+      title: 'dummy1',
+      countOfSell: 33303300,
+    },
+  ];
+  return (
+    <TopSellingListContainer>
+      <TopSellingTitle bgcolor={theme.greenColor}>Top Selling Goods</TopSellingTitle>
+      {mock.map((item, i) => (
+        <TopSellingGoods key={i} item={item} />
+      ))}
+    </TopSellingListContainer>
+  );
+};
+
+const TopSellingListContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 30%;
+  padding: 16px;
+`;
+
+const TopSellingTitle = styled('span')<{ bgcolor: string }>`
+  color: ${(props) => props.bgcolor};
+  height: 1.5em;
+  font-weight: 700;
+  margin-bottom: 30px;
+`;
+
+export default TopSellingGoodsList;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -30,11 +30,14 @@ const TopSellingGoodsList = () => {
 };
 
 const TopSellingContainer = styled('div')`
+  position: relative;
   display: flex;
   flex-direction: column;
-  width: 30%;
-  height: 50%;
+  width: 50%;
+  height: 100%;
   padding: 16px;
+  background-color: whitesmoke;
+  border-radius: 16px;
 `;
 const TopSellingTitleContainer = styled('div')`
   display: flex;
@@ -44,13 +47,14 @@ const GoodsListContainer = styled('div')`
   position: relative;
   display: flex;
   flex-direction: column;
+  height: 100%;
 `;
 
 const TopSellingTitle = styled('span')<{ bgcolor: string }>`
   color: ${(props) => props.bgcolor};
   height: 1.5em;
   font-weight: 700;
-  margin-bottom: 30px;
+  margin-bottom: 16px;
 `;
 
 export default TopSellingGoodsList;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -1,44 +1,45 @@
+import { GoodsAPI } from '@src/apis/goodsAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import TopSellingGoods from '@src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods';
 import { theme } from '@src/theme/theme';
-import React from 'react';
+import { GoodsItem } from '@src/types/Goods';
+import React, { useEffect, useState } from 'react';
 
 const TopSellingGoodsList = () => {
-  const mock = [
-    {
-      thumbnailUrl:
-        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-      title: 'dummy1',
-      countOfSell: 1330,
-    },
-    {
-      thumbnailUrl:
-        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-      title: 'dummy2dsasdasdasdasdasdasdasd',
-      countOfSell: 25500,
-    },
-    {
-      thumbnailUrl:
-        'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-      title: 'dummy1',
-      countOfSell: 33303300,
-    },
-  ];
+  const [goodsList, setGoodsList] = useState<GoodsItem[]>([]);
+  useEffect(() => {
+    async function fetchingGoodsList() {
+      const { result } = await GoodsAPI.getBestSellingGoodsForDashboard();
+      setGoodsList(result);
+    }
+    fetchingGoodsList();
+  }, []);
   return (
-    <TopSellingListContainer>
+    <TopSellingContainer>
       <TopSellingTitle bgcolor={theme.greenColor}>Top Selling Goods</TopSellingTitle>
-      {mock.map((item, i) => (
-        <TopSellingGoods key={i} item={item} />
-      ))}
-    </TopSellingListContainer>
+      <GoodsListContainer>
+        {goodsList.map((item, i) => (
+          <TopSellingGoods key={i} item={item} />
+        ))}
+      </GoodsListContainer>
+    </TopSellingContainer>
   );
 };
 
-const TopSellingListContainer = styled('div')`
+const TopSellingContainer = styled('div')`
   display: flex;
   flex-direction: column;
   width: 30%;
+  height: 50%;
   padding: 16px;
+  overflow: auto;
+`;
+
+const GoodsListContainer = styled('div')`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
 `;
 
 const TopSellingTitle = styled('span')<{ bgcolor: string }>`

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 
 const TopSellingGoodsList = () => {
   const [goodsList, setGoodsList] = useState<GoodsItem[]>([]);
+
   useEffect(() => {
     async function fetchingGoodsList() {
       const { result } = await GoodsAPI.getBestSellingGoodsForDashboard();
@@ -14,6 +15,7 @@ const TopSellingGoodsList = () => {
     }
     fetchingGoodsList();
   }, []);
+
   return (
     <TopSellingContainer>
       <TopSellingTitleContainer>

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -14,7 +14,7 @@ const TopSellingGoodsList = () => {
     {
       thumbnailUrl:
         'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg',
-      title: 'dummy2',
+      title: 'dummy2dsasdasdasdasdasdasdasd',
       countOfSell: 25500,
     },
     {

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -16,10 +16,13 @@ const TopSellingGoodsList = () => {
   }, []);
   return (
     <TopSellingContainer>
-      <TopSellingTitle bgcolor={theme.greenColor}>Top Selling Goods</TopSellingTitle>
+      <TopSellingTitleContainer>
+        <TopSellingTitle bgcolor={theme.greenColor}>Top Selling Goods</TopSellingTitle>
+        <TopSellingTitle bgcolor={theme.greenColor}>판매량</TopSellingTitle>
+      </TopSellingTitleContainer>
       <GoodsListContainer>
         {goodsList.map((item, i) => (
-          <TopSellingGoods key={i} item={item} />
+          <TopSellingGoods key={i} item={item} rank={i} />
         ))}
       </GoodsListContainer>
     </TopSellingContainer>
@@ -32,14 +35,15 @@ const TopSellingContainer = styled('div')`
   width: 30%;
   height: 50%;
   padding: 16px;
-  overflow: auto;
 `;
-
+const TopSellingTitleContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
 const GoodsListContainer = styled('div')`
   position: relative;
   display: flex;
   flex-direction: column;
-  overflow: auto;
 `;
 
 const TopSellingTitle = styled('span')<{ bgcolor: string }>`

--- a/frontend/admin/src/portal/GoodsUploadModal/UploadContentRight/GoodsCategoryUploader/GoodsCategoryUploader.tsx
+++ b/frontend/admin/src/portal/GoodsUploadModal/UploadContentRight/GoodsCategoryUploader/GoodsCategoryUploader.tsx
@@ -1,4 +1,4 @@
-import { CategoryAPI } from '@src/apis/categoryAPI';
+import CategoryAPI from '@src/apis/categoryAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import { UploaderLabel } from '@src/portal/GoodsUploadModal/UploadContentLeft/style';
 import { Category } from '@src/types/Category';

--- a/frontend/admin/src/theme/theme.ts
+++ b/frontend/admin/src/theme/theme.ts
@@ -14,4 +14,11 @@ export const theme = {
   dustWhite: '#F5F5F5',
   offWhite: '#FCFCFC',
   line: '#CCD3D3',
+
+  ChartColorRed: 'rgba(255, 99, 132, 0.6)',
+  ChartColorBlue: 'rgba(54, 162, 235, 0.6)',
+  ChartColorYellow: 'rgba(255, 206, 86, 0.6)',
+  ChartColorGreen: 'rgba(75, 192, 192, 0.6)',
+  ChartColorPurple: 'rgba(153, 102, 255, 0.6)',
+  ChartColorOrange: 'rgba(255, 159, 64, 0.6)',
 };

--- a/frontend/admin/src/types/Chart.ts
+++ b/frontend/admin/src/types/Chart.ts
@@ -1,0 +1,5 @@
+type PieData = {
+  name: string;
+  value: number;
+};
+export type PieChartData = PieData[];

--- a/frontend/admin/src/utils/convertCountOfSell.ts
+++ b/frontend/admin/src/utils/convertCountOfSell.ts
@@ -1,0 +1,14 @@
+const MILLION = 1000000;
+const K = 1000;
+
+export default function convertCountOfSell(num: number): string {
+  if (num >= MILLION) {
+    const new_num = Math.floor((num / MILLION) * 10) / 10;
+    return `${new_num}M`;
+  }
+  if (num >= K) {
+    const new_num = Math.floor((num / K) * 10) / 10;
+    return `${new_num}K`;
+  }
+  return `${num}`;
+}

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -1,5 +1,5 @@
 import { usePushHistory } from '@src/lib/CustomRouter/CustomRouter';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { BsHeart, BsFillBucketFill, BsFillHeartFill } from 'react-icons/bs';
 import { BestTag, GreenTag, NewTag, SaleTag } from '../Tag';
@@ -85,6 +85,11 @@ const GoodsItem: React.FC<Props> = ({
     },
     [isWished]
   );
+
+  useEffect(() => {
+    setIsWished(isWish);
+  }, [isWish]);
+
   return (
     <GoodsItemContainer onClick={handleClickGoodsItem}>
       <GoodsImageContainer onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave} size={itemBoxSize}>

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -86,7 +86,7 @@ const GoodsItem: React.FC<Props> = ({
     [isWished]
   );
   return (
-    <GoodsItemContainer onClick={handleClickGoodsItem} size={itemBoxSize}>
+    <GoodsItemContainer onClick={handleClickGoodsItem}>
       <GoodsImageContainer onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave} size={itemBoxSize}>
         <TagContainer>
           {isBest && <BestTag />}
@@ -117,7 +117,7 @@ const GoodsItem: React.FC<Props> = ({
 
 const ItemContainerWidthMap = {
   big: '300px',
-  middle: '260px',
+  middle: '25%',
   small: '200px',
 };
 
@@ -142,15 +142,11 @@ const TagContainer = styled.div`
   }
 `;
 
-interface GoodsItemContainerProps {
-  size: GoodsItemSize;
-}
-
-const GoodsItemContainer = styled.div<GoodsItemContainerProps>`
+const GoodsItemContainer = styled.div`
   position: relative;
   flex-grow: 0;
   flex-shrink: 0;
-  width: ${(props) => ItemContainerWidthMap[props.size]};
+  width: 25%;
   margin-top: 10px;
   margin-bottom: 10px;
   padding: 10px;

--- a/frontend/client/src/components/GoodsItemList/GoodsItemList.tsx
+++ b/frontend/client/src/components/GoodsItemList/GoodsItemList.tsx
@@ -27,7 +27,7 @@ const GoodsItemList: React.FC<Props> = ({ goodsList, itemBoxSize = 'big' }) => {
       {goodsList &&
         goodsList.map((goods) => (
           <GoodsItem
-            key={goods.isWish ? goods.id : goods.id * 2}
+            key={goods.id}
             id={goods.id}
             thumbnailUrl={goods.thumbnailUrl}
             title={goods.title}

--- a/frontend/client/src/components/GoodsItemList/GoodsItemList.tsx
+++ b/frontend/client/src/components/GoodsItemList/GoodsItemList.tsx
@@ -27,7 +27,7 @@ const GoodsItemList: React.FC<Props> = ({ goodsList, itemBoxSize = 'big' }) => {
       {goodsList &&
         goodsList.map((goods) => (
           <GoodsItem
-            key={goods.id}
+            key={goods.isWish ? goods.id : goods.id * 2}
             id={goods.id}
             thumbnailUrl={goods.thumbnailUrl}
             title={goods.title}

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -8,6 +8,8 @@ import Footer from '@src/components/Footer/Footer';
 import SideBar from './SideBar/SideBar';
 import { getMainGoodsListMap } from '@src/apis/goodsAPI';
 import { getPromotions } from '@src/apis/promotionAPI';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@src/recoil/userState';
 
 const mockProductImagePath =
   'https://user-images.githubusercontent.com/20085849/128866958-900ad32a-cd32-4b97-be79-1dbbc9dcb02d.jpeg';
@@ -29,6 +31,8 @@ const mock_best_products: ThumbnailGoods[] = [
 
 const Main = () => {
   const [promotions, setPromotions] = useState<Promotion[]>([]);
+  const userRecoil = useRecoilValue(userState);
+
   const fetchPromotions = async () => {
     const { result } = await getPromotions();
     setPromotions(result);
@@ -44,7 +48,7 @@ const Main = () => {
   useEffect(() => {
     fetchPromotions();
     fetchMainGoodsListMap();
-  }, []);
+  }, [userRecoil]);
 
   return (
     mainGoodsListMap && (

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -73,8 +73,9 @@ const PromotionContainer = styled.div`
 `;
 
 const MainContentContainer = styled.div`
-  width: 1200px;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 1280px;
+  padding: 0 15% 0 15%;
 `;
 
 interface FooterContainerProps {


### PR DESCRIPTION
## :bookmark_tabs: 제목
대시보드- 상품 카테고리 비율 차트, TOP 상품 컴포넌트 개발 
클라이언트 (로그인,로그아웃 메인 UX 개선)

## 대시보드 (카테고리 비율 파이차트, Top 5 상품 컴포넌트 )

https://user-images.githubusercontent.com/18898526/130407138-f0f93911-5b9a-4166-a782-09513ea4ab84.mov

## 로그인 로그아웃시 메인 리스트 re fetching


https://user-images.githubusercontent.com/18898526/130407208-36bfd2ce-56e5-45ae-bf61-650e879da603.mov


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Admin 대시보드 TOP 상품 컴포넌트 개발 (API 연동) 
- [x] 상품 카테고리 비율 차트 (API 연동)
- [x] 메인 품목리스트 min-width : 1280px 과 padding 0 15% 0 15% 로 헤더와 균형 맞춤
- [x] 로그인, 로그아웃 시 메인 List 다시 Fetching 하도록 수행

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- isWish가 props로 주어짐에도 불구하고, useState로 wish를 따로 상태관리하고 있어서 rendering이 되지 않는 점을 해결하기 위해
useEffect에서 isWish 값에 따라 다시 렌더링이 될 수 있도록 로직을 추가했습니다

![image](https://user-images.githubusercontent.com/18898526/130413017-94aec132-6a58-44b4-a91f-877847834a85.png)


- 차트 애니메이션의 경우 오른쪽 탑 5 상품이 렌더링 되는 속도와 차이가 나다보니 너무 어색해서 아래 Component들이 구현되고나서 애니메이션을 구상해봐야할 것 같습니다.
