### PR TITLE
[feuatre/154] 장바구니 관련 비즈니스 로직 완성

### DIFF
--- a/backend/src/repository/goods.repository.ts
+++ b/backend/src/repository/goods.repository.ts
@@ -195,6 +195,10 @@ async function increaseGoodsViewById(goodsId: number): Promise<void> {
   }
 }
 
+async function decrementStock(id: number, amount: number) {
+  return await getRepository(Goods).decrement({ id }, 'stock', amount);
+}
+
 export const GoodsRepository = {
   findGoodsById,
   findGoodsDetailById,
@@ -207,4 +211,5 @@ export const GoodsRepository = {
   findBestSellingGoods,
   searchGoodsFromKeyword,
   increaseGoodsViewById,
+  decrementStock,
 };

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -1,6 +1,6 @@
 import { CreateOrder } from './../types/request/order.request';
 import { Order } from '../entity/Order';
-import { getRepository } from 'typeorm';
+import { getRepository, EntityManager } from 'typeorm';
 import { DatabaseError } from '../errors/base.error';
 import { ORDER_LIST_DB_ERROR } from '../constants/database.error.name';
 import { PaginationProps } from '../types/Pagination';
@@ -71,11 +71,15 @@ async function getAllOrdersPagination({ offset, limit }: PaginationProps): Promi
   }
 }
 
-async function createOrder(userId: number, body: CreateOrder): Promise<Order> {
+async function createOrder(
+  transactionalEntityManager: EntityManager,
+  userId: number,
+  body: CreateOrder
+): Promise<Order> {
   try {
     const { orderMemo, receiver, zipCode, address, subAddress, paymentId } = body;
-    const orderRepo = getRepository(Order);
-    return await orderRepo.save({
+
+    return await transactionalEntityManager.save(Order, {
       user: {
         id: userId,
       },

--- a/backend/src/service/cart.service.ts
+++ b/backend/src/service/cart.service.ts
@@ -17,11 +17,6 @@ async function getAllCartByUserId(userId: number): Promise<CartsResponse> {
     return { ...rawCart, amount: Math.min(amount, goods.stock) };
   });
 
-  // amount가 0 초과가 아닌 장바구니 항목은 DB에서 제거한다.
-  for (const { id, amount } of carts) {
-    if (!(amount > 0)) await CartRepository.deleteCart(id);
-  }
-
   return carts.filter(({ amount }) => amount > 0);
 }
 

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -357,10 +357,6 @@ async function checkValidateCreateGoods(body: CreateGoodsBody): Promise<void> {
   if (!foundDeliveryInfo) throw new BadRequestError(INVALID_DELIVERY_INFO);
 }
 
-async function decrementStock(id: number, amount: number) {
-  await GoodsRepository.decrementStock(id, amount);
-}
-
 export const GoodsService = {
   createGoods,
   updateGoods,
@@ -371,5 +367,4 @@ export const GoodsService = {
   getGoodsStockById,
   getGoodsImgById,
   getBestSellingGoodsForDashboard,
-  decrementStock,
 };

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -357,6 +357,10 @@ async function checkValidateCreateGoods(body: CreateGoodsBody): Promise<void> {
   if (!foundDeliveryInfo) throw new BadRequestError(INVALID_DELIVERY_INFO);
 }
 
+async function decrementStock(id: number, amount: number) {
+  await GoodsRepository.decrementStock(id, amount);
+}
+
 export const GoodsService = {
   createGoods,
   updateGoods,
@@ -367,4 +371,5 @@ export const GoodsService = {
   getGoodsStockById,
   getGoodsImgById,
   getBestSellingGoodsForDashboard,
+  decrementStock,
 };

--- a/backend/src/service/order.service.ts
+++ b/backend/src/service/order.service.ts
@@ -70,7 +70,7 @@ async function createOrder(userId: number, body: CreateOrderBody): Promise<Order
 
   const { orderMemo, receiver, zipCode, address, subAddress, paymentId, goodsList, cartIds } = body;
 
-  // 재고 변경
+  // 재고 감소
   for (const { id, amount } of goodsList) {
     await GoodsService.decrementStock(id, amount);
   }

--- a/backend/src/service/order.service.ts
+++ b/backend/src/service/order.service.ts
@@ -12,6 +12,7 @@ import { OrderListPaginationResponse } from '../types/response/order.response';
 import { getTotalPage, pagination } from '../utils/pagination';
 import { PaginationProps } from '../types/Pagination';
 import { PaymentRepository } from '../repository/payment.repository';
+import CartService from './cart.service';
 
 async function getOwnOrdersPagination(
   { page, limit }: GetAllOrderByUserIdProps,
@@ -65,7 +66,7 @@ async function getAllOrdersPagination({ page, limit }: GetAllOrderByUserIdProps)
 async function createOrder(userId: number, body: CreateOrderBody): Promise<Order> {
   const validateResult = await validateCreateOrder(body);
   if (!validateResult) throw new BadRequestError(INVALID_DATA);
-  const { orderMemo, receiver, zipCode, address, subAddress, paymentId, goodsList } = body;
+  const { orderMemo, receiver, zipCode, address, subAddress, paymentId, goodsList, cartIds } = body;
   const order = await OrderListRepository.createOrder(userId, {
     orderMemo,
     receiver,
@@ -75,6 +76,9 @@ async function createOrder(userId: number, body: CreateOrderBody): Promise<Order
     paymentId,
   });
   await Promise.all(goodsList.map((orderedItem) => createOrderItem(orderedItem, order.id)));
+  if (cartIds) {
+    await CartService.deleteCarts(userId, cartIds);
+  }
   return order;
 }
 

--- a/backend/src/types/request/order.request.ts
+++ b/backend/src/types/request/order.request.ts
@@ -8,6 +8,7 @@ export interface CreateOrder {
   address: string;
   subAddress: string;
   paymentId: number;
+  cartIds?: number[];
 }
 
 export interface CreateOrderBody extends CreateOrder {

--- a/frontend/client/src/apis/orderAPI.ts
+++ b/frontend/client/src/apis/orderAPI.ts
@@ -14,6 +14,7 @@ interface SubmitOrderBody {
   subAddress: string;
   goodsList: GoodsInfoForOrder[];
   paymentId: number;
+  cartIds?: number[];
 }
 
 export const submitOrder = async (orderData: SubmitOrderBody): Promise<boolean> => {

--- a/frontend/client/src/hooks/usePushToOrderPage.ts
+++ b/frontend/client/src/hooks/usePushToOrderPage.ts
@@ -8,12 +8,12 @@ const usePushToOrderPage = () => {
   const [_, setOrderState] = useRecoilState(orderState);
   const pushHistory = usePushHistory();
 
-  async function setOrderGoodsList(orderGoodsList: GoodsBeforeOrder[]) {
-    setOrderState(orderGoodsList);
+  async function setOrderGoodsList(orderGoodsList: GoodsBeforeOrder[], cartIds?: number[]) {
+    setOrderState({ goodsList: orderGoodsList, cartIds });
   }
 
-  const pushToOrderPage = async (orderGoodsList: GoodsBeforeOrder[]) => {
-    await setOrderGoodsList(orderGoodsList);
+  const pushToOrderPage = async (orderGoodsList: GoodsBeforeOrder[], cartIds?: number[]) => {
+    await setOrderGoodsList(orderGoodsList, cartIds);
     pushHistory('/order');
   };
 

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -62,7 +62,7 @@ const CartPage: React.FC = () => {
 
   const handleClickOrderButton = () => {
     const filteredCartGoodsList = cartGoodsList.filter((cartGoods) => cartGoods.isSelected);
-    const cartIds = cartGoodsList.map((cartGoods) => cartGoods.id);
+    const cartIds = filteredCartGoodsList.map((cartGoods) => cartGoods.id);
     pushToOrderPage(filteredCartGoodsList, cartIds);
   };
 

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -62,7 +62,8 @@ const CartPage: React.FC = () => {
 
   const handleClickOrderButton = () => {
     const filteredCartGoodsList = cartGoodsList.filter((cartGoods) => cartGoods.isSelected);
-    pushToOrderPage(filteredCartGoodsList);
+    const cartIds = cartGoodsList.map((cartGoods) => cartGoods.id);
+    pushToOrderPage(filteredCartGoodsList, cartIds);
   };
 
   useEffect(() => {

--- a/frontend/client/src/pages/Order/OrderPage.tsx
+++ b/frontend/client/src/pages/Order/OrderPage.tsx
@@ -30,7 +30,7 @@ const NEED_AGREEMENT_MESSAGE = '결제 진행에 필요한 사항을 동의해�
 const DEFAULT_ORDER_MEMO = '부재 시 연락바랍니다.';
 
 const OrderPage: React.FC = () => {
-  const orderGoodsList = useRecoilValue(orderState);
+  const { goodsList: orderGoodsList, cartIds } = useRecoilValue(orderState);
   const [selectedAddress, setSelectedAddress] = useState<AddressInfo | null>(null);
   const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(null);
   const [isAgreementChecked, setIsAgreementChecked] = useState(false);
@@ -68,6 +68,7 @@ const OrderPage: React.FC = () => {
       orderMemo: DEFAULT_ORDER_MEMO,
       paymentId: selectedPaymentId,
       goodsList: orderGoodsList.map(({ amount, goods }) => ({ amount, id: goods.id })),
+      cartIds,
     };
 
     await submitOrder(submitOrderBody);

--- a/frontend/client/src/recoil/orderState.ts
+++ b/frontend/client/src/recoil/orderState.ts
@@ -1,7 +1,14 @@
 import { GoodsBeforeOrder } from '@src/types/Goods';
 import { atom } from 'recoil';
 
-export const orderState = atom<GoodsBeforeOrder[]>({
+interface OrderState {
+  goodsList: GoodsBeforeOrder[];
+  cartIds?: number[];
+}
+
+export const orderState = atom<OrderState>({
   key: 'orderState',
-  default: [],
+  default: {
+    goodsList: [],
+  },
 });


### PR DESCRIPTION
## :bookmark_tabs: 장바구니 관련 비즈니스 로직 완성



https://user-images.githubusercontent.com/64543699/130441870-b5308fd3-12c0-4307-b846-a6da1cd0dd11.mov



## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 주문 생성 API 요청 시 cartIds를 선택적으로 전달하고, 백엔드에선 그에 따라 사용자 장바구니를 지워주는 로직
- [x] 주문 생성 API 요청 시, 주문 수량 만큼 재고를 줄이는 로직
- [x] 장바구니 조회 시, 상품 재고에 따른 필터링 로직

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 타입과 백엔드 '로직 무결성' 위주로 봐주시면 좋을것 같습니다. 트랜잭션이 필요할까요?
