### PR TITLE
[feature/] 관리자 페이지 주문 조회 화면 개발 및 대시보드 속 실시간 주문 현황 컴포넌트 개발 

### DIFF
--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -42,7 +42,7 @@ async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId
       skip: offset,
       take: limit,
       order: {
-        createdAt: 'ASC',
+        createdAt: 'DESC',
       },
     });
   } catch (err) {

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -35,7 +35,7 @@ async function getOwnOrderTotalCount(userId: number): Promise<number> {
 async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId: number): Promise<Order[]> {
   try {
     return await getRepository(Order).find({
-      relations: ['payment', 'orderItems', 'orderItems.goods'],
+      relations: ['payment', 'orderItems', 'orderItems.goods', 'user'],
       where: {
         user: { id: userId },
       },

--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -13,21 +13,17 @@ export default function App() {
       <Router>
         <Header />
         <Routes>
-          <Route path='/admin'>
-            <Routes>
-              <Route path='/admin/goods'>
-                <GoodsAdmin />
-              </Route>
-              <Route path='/admin/order'>
-                <OrderAdmin />
-              </Route>
-              <Route path='/admin/promotion'>
-                <PromotionAdmin />
-              </Route>
-              <Route path='/admin'>
-                <Main />
-              </Route>
-            </Routes>
+          <Route path='/admin/goods'>
+            <GoodsAdmin />
+          </Route>
+          <Route path='/admin/order'>
+            <OrderAdmin />
+          </Route>
+          <Route path='/admin/promotion'>
+            <PromotionAdmin />
+          </Route>
+          <Route path='/'>
+            <Main />
           </Route>
         </Routes>
       </Router>

--- a/frontend/admin/src/apis/orderAPI.ts
+++ b/frontend/admin/src/apis/orderAPI.ts
@@ -1,0 +1,23 @@
+import { APIResponse, checkedFetch } from '@src/apis/base';
+import { OrderPaginationResult } from '@src/types/Order';
+
+const DEFAULT_ORDER_LIMIT = 5;
+
+export interface GetOrdersProps {
+  page: number;
+  limit?: number;
+}
+
+export const getOrders = async ({
+  page,
+  limit = DEFAULT_ORDER_LIMIT,
+}: GetOrdersProps): Promise<APIResponse<OrderPaginationResult>> => {
+  const res = await checkedFetch(`/api/order?page=${page}&limit=${limit}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  return await res.json();
+};

--- a/frontend/admin/src/hooks/useInterval.ts
+++ b/frontend/admin/src/hooks/useInterval.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface IntervalHook {
+  (callback: any, delay: number): void;
+}
+
+const useInterval: IntervalHook = (callback, delay) => {
+  const savedCallback = useRef<any>();
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => {
+        clearInterval(id);
+      };
+    }
+  }, [callback, delay]);
+};
+
+export default useInterval;

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
@@ -58,6 +58,4 @@ const ThumbnailImg = styled('img')`
   height: 40px;
 `;
 
-// const GoodsItemRow =
-
 export default GoodsTableRow;

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
@@ -11,9 +11,8 @@ const LiveOrderCard: React.FC<LiveOrderCardProps> = ({ order }) => {
   const { id, orderItems, user, createdAt } = order;
   const firstOrderItems = orderItems[0];
   return (
-    <>
+    <div>
       <LiveOrderTitle>{convertYYYYMMDDHHMMSS(new Date(createdAt))}</LiveOrderTitle>
-
       <LiveOrderCardContainer key={id}>
         <img width={50} height={50} src={firstOrderItems.goods.thumbnailUrl} />
         <div>
@@ -23,7 +22,7 @@ const LiveOrderCard: React.FC<LiveOrderCardProps> = ({ order }) => {
         <LiveOrderCardUserImg src={user.profileImgUrl} />
         <div> {user.name} </div>
       </LiveOrderCardContainer>
-    </>
+    </div>
   );
 };
 
@@ -32,7 +31,7 @@ const LiveOrderCardContainer = styled('div')`
   align-items: center;
   justify-content: space-between;
   padding: 14px;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
   border-radius: 0px 14px 14px 14px;
   background-color: white;
 
@@ -54,8 +53,6 @@ const LiveOrderTitle = styled('p')`
   font-weight: 500;
   width: 140px;
   padding: 5px;
-  border-radius: 14px 14px 0px 0px;
-  background-color: white;
 `;
 
 const LiveOrderCardUserImg = styled('img')`

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
@@ -1,0 +1,69 @@
+import { Order } from '@src/types/Order';
+import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
+import React from 'react';
+import styled from 'styled-components';
+
+interface LiveOrderCardProps {
+  order: Order;
+}
+
+const LiveOrderCard: React.FC<LiveOrderCardProps> = ({ order }) => {
+  const { id, orderItems, user, createdAt } = order;
+  const firstOrderItems = orderItems[0];
+  return (
+    <>
+      <LiveOrderTitle>{convertYYYYMMDDHHMMSS(new Date(createdAt))}</LiveOrderTitle>
+
+      <LiveOrderCardContainer key={id}>
+        <img width={50} height={50} src={firstOrderItems.goods.thumbnailUrl} />
+        <div>
+          {firstOrderItems.goods.title}
+          {orderItems.length > 1 && <span>외 {orderItems.length} 개</span>}
+        </div>
+        <LiveOrderCardUserImg src={user.profileImgUrl} />
+        <div> {user.name} </div>
+      </LiveOrderCardContainer>
+    </>
+  );
+};
+
+const LiveOrderCardContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px;
+  margin-bottom: 10px;
+  border-radius: 0px 14px 14px 14px;
+  background-color: white;
+
+  animation-name: orderCardShowEffect;
+  animation-duration: 0.3s;
+
+  @keyframes orderCardShowEffect {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const LiveOrderTitle = styled('p')`
+  font-size: 12px;
+  font-weight: 500;
+  width: 140px;
+  padding: 5px;
+  border-radius: 14px 14px 0px 0px;
+  background-color: white;
+`;
+
+const LiveOrderCardUserImg = styled('img')`
+  border-radius: 50%;
+  border: 1px solid #c0c0c0;
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+`;
+
+export default LiveOrderCard;

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -5,7 +5,7 @@ import LiveOrderCard from '@src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrder
 import { theme } from '@src/theme/theme';
 import { Order } from '@src/types/Order';
 import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 const DEFAULT_LIVE_ORDER_LIMIT = 10;
 const DEFAULT_START_PAGE = 0;
@@ -15,12 +15,18 @@ const LiveOrderList = () => {
   const [updateTime, setUpdateTime] = useState<Date>(new Date());
   const [orders, setOrder] = useState<Order[]>([]);
 
-  const poller = useCallback(async () => {
+  const updateOrders = async () => {
     setUpdateTime(new Date());
     const {
       result: { orderList },
     } = await getOrders({ page: DEFAULT_START_PAGE, limit: DEFAULT_LIVE_ORDER_LIMIT });
     setOrder(orderList);
+  };
+
+  const poller = useCallback(updateOrders, []);
+
+  useEffect(() => {
+    updateOrders();
   }, []);
 
   useInterval(poller, POLLING_INTERVAL_MILLISECONDS); // 1초마다 폴링

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -5,25 +5,32 @@ import LiveOrderCard from '@src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrder
 import { theme } from '@src/theme/theme';
 import { Order } from '@src/types/Order';
 import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+
+const DEFAULT_LIVE_ORDER_LIMIT = 10;
+const DEFAULT_START_PAGE = 0;
+const POLLING_INTERVAL_MILLISECONDS = 2000;
 
 const LiveOrderList = () => {
-  const [updating, setUpdating] = useState<boolean>(false);
+  const [updateTime, setUpdateTime] = useState<Date>(new Date());
   const [orders, setOrder] = useState<Order[]>([]);
 
   const poller = useCallback(async () => {
-    setUpdating(!updating);
+    setUpdateTime(new Date());
     const {
       result: { orderList },
-    } = await getOrders({ page: 0, limit: 10 });
+    } = await getOrders({ page: DEFAULT_START_PAGE, limit: DEFAULT_LIVE_ORDER_LIMIT });
     setOrder(orderList);
   }, []);
 
-  useInterval(poller, 1000);
+  useInterval(poller, POLLING_INTERVAL_MILLISECONDS); // 1초마다 폴링
 
   return (
     <LiveOrderListContainer>
       <LiveOrderListTitle color={theme.greenColor}>주문 현황</LiveOrderListTitle>
+      <LatestUpdateTime color={theme.greenColor}>
+        (최근 업데이트 시간: {convertYYYYMMDDHHMMSS(updateTime)})
+      </LatestUpdateTime>
       <LiveOrderItemContainer>
         {orders.map((order) => (
           <LiveOrderCard key={order.id} order={order} />
@@ -46,6 +53,11 @@ const LiveOrderListTitle = styled('span')<{ color: string }>`
   height: 1.5em;
   font-weight: 700;
   margin-bottom: 16px;
+`;
+
+const LatestUpdateTime = styled('span')<{ color: string }>`
+  color: ${(props) => props.color};
+  font-size: 10px;
 `;
 
 const LiveOrderItemContainer = styled('div')`

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -7,7 +7,7 @@ import { Order } from '@src/types/Order';
 import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
 import React, { useCallback, useEffect, useState } from 'react';
 
-const DEFAULT_LIVE_ORDER_LIMIT = 10;
+const DEFAULT_LIVE_ORDER_LIMIT = 7;
 const DEFAULT_START_PAGE = 0;
 const POLLING_INTERVAL_MILLISECONDS = 2000;
 
@@ -68,6 +68,7 @@ const LatestUpdateTime = styled('span')<{ color: string }>`
 
 const LiveOrderItemContainer = styled('div')`
   margin-top: 20px;
+  overflow: scroll;
 `;
 
 const LiveOrderItem = styled('div')`

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -15,21 +15,19 @@ const LiveOrderList = () => {
   const [updateTime, setUpdateTime] = useState<Date>(new Date());
   const [orders, setOrder] = useState<Order[]>([]);
 
-  const updateOrders = async () => {
+  const updateOrders = useCallback(async () => {
     setUpdateTime(new Date());
     const {
       result: { orderList },
     } = await getOrders({ page: DEFAULT_START_PAGE, limit: DEFAULT_LIVE_ORDER_LIMIT });
     setOrder(orderList);
-  };
-
-  const poller = useCallback(updateOrders, []);
+  }, [setOrder, setUpdateTime]);
 
   useEffect(() => {
     updateOrders();
   }, []);
 
-  useInterval(poller, POLLING_INTERVAL_MILLISECONDS); // 1초마다 폴링
+  useInterval(updateOrders, POLLING_INTERVAL_MILLISECONDS); // 1초마다 폴링
 
   return (
     <LiveOrderListContainer>

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -1,0 +1,62 @@
+import { getOrders } from '@src/apis/orderAPI';
+import useInterval from '@src/hooks/useInterval';
+import { styled } from '@src/lib/CustomStyledComponent';
+import LiveOrderCard from '@src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard';
+import { theme } from '@src/theme/theme';
+import { Order } from '@src/types/Order';
+import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
+import React, { useCallback, useEffect, useState } from 'react';
+
+const LiveOrderList = () => {
+  const [updating, setUpdating] = useState<boolean>(false);
+  const [orders, setOrder] = useState<Order[]>([]);
+
+  const poller = useCallback(async () => {
+    setUpdating(!updating);
+    const {
+      result: { orderList },
+    } = await getOrders({ page: 0, limit: 10 });
+    setOrder(orderList);
+  }, []);
+
+  useInterval(poller, 1000);
+
+  return (
+    <LiveOrderListContainer>
+      <LiveOrderListTitle color={theme.greenColor}>주문 현황</LiveOrderListTitle>
+      <LiveOrderItemContainer>
+        {orders.map((order) => (
+          <LiveOrderCard key={order.id} order={order} />
+        ))}
+      </LiveOrderItemContainer>
+    </LiveOrderListContainer>
+  );
+};
+
+const LiveOrderListContainer = styled('div')`
+  margin-left: 16px;
+  padding: 16px;
+  background-color: whitesmoke;
+  border-radius: 16px;
+  height: 100%;
+`;
+
+const LiveOrderListTitle = styled('span')<{ color: string }>`
+  color: ${(props) => props.color};
+  height: 1.5em;
+  font-weight: 700;
+  margin-bottom: 16px;
+`;
+
+const LiveOrderItemContainer = styled('div')`
+  margin-top: 20px;
+`;
+
+const LiveOrderItem = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px;
+`;
+
+export default LiveOrderList;

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { styled } from '@src/lib/CustomStyledComponent';
 import TopSellingGoodsList from '@src/pages/Main/TopSellingGoodsList/TopSellingGoodsList';
 import CategoryPieChart from '@src/pages/Main/CategoryPieChart/CategoryPieChart';
+import LiveOrderList from '@src/pages/Main/LiveOrderList/LiveOrderList';
 
 const Main = () => {
   return (
@@ -13,7 +14,9 @@ const Main = () => {
         </LeftTopContainer>
         <div>왼쪽 하단</div>
       </LeftContainer>
-      <RightContainer>오른쪽 한열</RightContainer>
+      <RightContainer>
+        <LiveOrderList />
+      </RightContainer>
     </MainContainer>
   );
 };
@@ -40,6 +43,9 @@ const LeftTopContainer = styled('div')`
   height: 100%;
 `;
 
-const RightContainer = styled('div')``;
+const RightContainer = styled('div')`
+  width: 40%;
+  height: 100%;
+`;
 
 export default Main;

--- a/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
@@ -1,7 +1,75 @@
-import React from 'react';
+import { getOrders } from '@src/apis/orderAPI';
+import Loading from '@src/components/Loading/Loading';
+import Paginator from '@src/components/Paginator/Paginator';
+import OrderTable from '@src/pages/OrderAdmin/OrderTable/OrderTable';
+import { Order, OrderPaginationResult } from '@src/types/Order';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+const DEFAULT_START_PAGE = 0;
+const DEFAULT_LIMIT_ORDER = 10;
 
 const OrderAdmin = () => {
-  return <div>주문 관리 페이지</div>;
+  const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
+
+  const fetchOrders = async () => {
+    try {
+      const { result } = await getOrders({
+        page: currentPage,
+        limit: DEFAULT_LIMIT_ORDER,
+      });
+      setOrderPaginationResult(result);
+      setErrorMessage('');
+    } catch (err) {
+      setErrorMessage('주문 정보를 불러오는데 실패했습니다.');
+    }
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, [currentPage]);
+
+  return (
+    <OrderAdminContainer>
+      <TitleSection>
+        <Title>주문 관리</Title>
+        <p>총 주문 {orderPaginationResult?.meta.totalCount} 건</p>
+        <span>{errorMessage}</span>
+      </TitleSection>
+
+      {orderPaginationResult ? <OrderTable orderList={orderPaginationResult.orderList} /> : <Loading />}
+
+      {orderPaginationResult && (
+        <Paginator
+          totalPage={orderPaginationResult.meta.totalPage}
+          currentPage={orderPaginationResult.meta.page}
+          setPage={setCurrentPage}
+        />
+      )}
+    </OrderAdminContainer>
+  );
 };
+
+const OrderAdminContainer = styled('div')`
+  position: relative;
+  width: 100%;
+  margin: 5rem;
+`;
+
+const Title = styled('h2')`
+  font-size: 24px;
+  font-weight: 600;
+  margin-right: 1rem;
+`;
+
+const TitleSection = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: flex-start;
+  margin-bottom: 20px;
+`;
 
 export default OrderAdmin;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTable.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTable.tsx
@@ -1,0 +1,25 @@
+import OrderTableBody from '@src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableBody';
+import OrderTableHead from '@src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableHead';
+import { Order } from '@src/types/Order';
+import React from 'react';
+import styled from 'styled-components';
+
+interface OrderTableProps {
+  orderList: Order[];
+}
+
+const OrderTable: React.FC<OrderTableProps> = ({ orderList }) => {
+  return (
+    <OrderTableContainer>
+      <OrderTableHead />
+      <OrderTableBody orderList={orderList} />
+    </OrderTableContainer>
+  );
+};
+
+const OrderTableContainer = styled.div`
+  width: 100%;
+  min-height: 650px;
+`;
+
+export default OrderTable;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { styled } from '@src/lib/CustomStyledComponent';
+import originStyled from 'styled-components';
+import { Order } from '@src/types/Order';
+import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
+
+interface OrderRowProps {
+  order: Order;
+}
+
+const OrderRow: React.FC<OrderRowProps> = ({ order }) => {
+  const firstGoods = order.orderItems[0];
+  return (
+    <OrderRowContainer>
+      <OrderRowCell>
+        <p>{order.id}</p>
+      </OrderRowCell>
+      <OrderRowCell>{convertYYYYMMDDHHMMSS(new Date(order.createdAt))}</OrderRowCell>
+      <OrderItemRowCell>
+        {order.orderItems.map((orderItem, idx) => {
+          return <OrderItemImg key={idx} src={orderItem.goods.thumbnailUrl} />;
+        })}
+      </OrderItemRowCell>
+      <OrderUserRowCell>
+        <UserThumbnailImg src={order.user.profileImgUrl} />
+        <p>{order.user.name}</p>
+      </OrderUserRowCell>
+      <OrderRowCell>
+        {order.address}/ {order.subAddress}
+      </OrderRowCell>
+      <OrderRowCell>{order.payment.type}</OrderRowCell>
+      <OrderRowCell>{order.state}</OrderRowCell>
+    </OrderRowContainer>
+  );
+};
+
+const OrderRowContainer = originStyled.li`
+  display: grid;
+  grid-template-columns: 0.5fr 1fr 2fr 1fr 1fr 1fr 1fr;
+  height: 60px;
+  cursor: pointer;
+  transition: background-color 0.15s linear;
+  :hover {
+    background-color: rgba(0, 0, 0, 0.15);
+  }
+`;
+
+const OrderRowCell = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const OrderItemRowCell = styled('ul')`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  overflow-x: scroll;
+`;
+
+const OrderItemImg = styled('img')`
+  width: 50px;
+  height: 50px;
+  border: 1px solid #c0c0c0;
+
+  margin-right: 2px;
+`;
+
+const OrderUserRowCell = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+const UserThumbnailImg = styled('img')`
+  border-radius: 50%;
+  border: 1px solid #c0c0c0;
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+  margin-right: 2px;
+`;
+
+export default OrderRow;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
@@ -64,7 +64,6 @@ const OrderItemImg = styled('img')`
   width: 50px;
   height: 50px;
   border: 1px solid #c0c0c0;
-
   margin-right: 2px;
 `;
 

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableBody.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableBody.tsx
@@ -1,0 +1,26 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import OrderRow from '@src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow';
+import { Order } from '@src/types/Order';
+import React from 'react';
+
+interface OrderTableBodyProps {
+  orderList: Order[];
+}
+
+const OrderTableBody: React.FC<OrderTableBodyProps> = ({ orderList }) => {
+  return (
+    <OrderTableBodyContainer>
+      {orderList.map((order) => (
+        <OrderRow key={order.id} order={order} />
+      ))}
+    </OrderTableBodyContainer>
+  );
+};
+
+const OrderTableBodyContainer = styled('ul')`
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+`;
+
+export default OrderTableBody;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableHead.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableHead.tsx
@@ -1,0 +1,32 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import React from 'react';
+
+const OrderTableHead = () => {
+  return (
+    <Head>
+      <HeadCell>주문ID</HeadCell>
+      <HeadCell>주문일시</HeadCell>
+      <HeadCell>주문상품</HeadCell>
+      <HeadCell>고객</HeadCell>
+      <HeadCell>주문주소</HeadCell>
+      <HeadCell>결제수단</HeadCell>
+      <HeadCell>주문상태</HeadCell>
+    </Head>
+  );
+};
+
+const Head = styled('div')`
+  display: grid;
+  grid-template-columns: 0.5fr 1fr 2fr 1fr 1fr 1fr 1fr;
+  height: 50px;
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const HeadCell = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default OrderTableHead;

--- a/frontend/admin/src/types/Goods.ts
+++ b/frontend/admin/src/types/Goods.ts
@@ -37,3 +37,17 @@ export interface GetGoodsByOptionProps {
   order?: string;
   sort?: 'ASC' | 'DESC';
 }
+
+export interface Goods {
+  id: number;
+  thumbnailUrl?: string; // thumbnailUrl
+  title: string;
+  price: number;
+  isBest?: boolean;
+  isGreen?: boolean;
+  isNew?: boolean;
+  isSale?: boolean;
+  discountRate: number;
+  isWish?: boolean;
+  stock?: number;
+}

--- a/frontend/admin/src/types/Order.ts
+++ b/frontend/admin/src/types/Order.ts
@@ -1,0 +1,48 @@
+import { Goods } from '@src/types/Goods';
+
+export interface Payment {
+  id: number;
+  name: string;
+  type: string;
+}
+
+export interface OrderItem {
+  id: string;
+  amount: number;
+  price: number;
+  discountRate: number;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+  goods: Goods;
+}
+export interface OrderUser {
+  id: number;
+  name: string;
+  profileImgUrl: string;
+}
+
+export interface Order {
+  id: number;
+  address: string;
+  orderMemo: string;
+  receiver: string;
+  state: string;
+  subAddress: string;
+  payment: Payment;
+  zipCode: string;
+  updatedAt: string;
+  createdAt: string;
+  orderItems: OrderItem[];
+  user: OrderUser;
+}
+
+export interface OrderPaginationResult {
+  orderList: Order[];
+  meta: {
+    page: number;
+    limit: number;
+    totalPage: number;
+    totalCount: number;
+  };
+}

--- a/frontend/admin/src/utils/dateHelper.ts
+++ b/frontend/admin/src/utils/dateHelper.ts
@@ -1,3 +1,8 @@
 export function convertYYYYMMDD(date: Date) {
   return `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${('0' + date.getDate()).slice(-2)}`;
 }
+
+export function convertYYYYMMDDHHMMSS(date: Date) {
+  return `${date.getFullYear()}-${('0' + date.getMonth()).slice(-2)}-${('0' + date.getDate()).slice(-2)} 
+  ${('0' + date.getHours()).slice(-2)}:${('0' + date.getMinutes()).slice(-2)}:${('0' + date.getSeconds()).slice(-2)}`;
+}

--- a/frontend/admin/src/utils/dateHelper.ts
+++ b/frontend/admin/src/utils/dateHelper.ts
@@ -3,6 +3,6 @@ export function convertYYYYMMDD(date: Date) {
 }
 
 export function convertYYYYMMDDHHMMSS(date: Date) {
-  return `${date.getFullYear()}-${('0' + date.getMonth()).slice(-2)}-${('0' + date.getDate()).slice(-2)} 
+  return `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${('0' + date.getDate()).slice(-2)} 
   ${('0' + date.getHours()).slice(-2)}:${('0' + date.getMinutes()).slice(-2)}:${('0' + date.getSeconds()).slice(-2)}`;
 }

--- a/frontend/admin/webpack.common.js
+++ b/frontend/admin/webpack.common.js
@@ -63,7 +63,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'admin_bundle.js',
-    publicPath: '/',
+    publicPath: '/dist',
   },
 
   plugins: [

--- a/frontend/admin/webpack.dev.js
+++ b/frontend/admin/webpack.dev.js
@@ -6,14 +6,12 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    index: 'admin_index.html',
-    contentBase: path.join(__dirname, 'dist'),
-    index: 'admin_index.html',
-    publicPath: '/',
     overlay: true,
     port: 8082,
     stats: 'errors-only',
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/dist/admin_index.html',
+    },
     proxy: {
       '/api': 'http://localhost:8080',
     },

--- a/frontend/client/src/components/SideBar/RecentGoodsView.tsx
+++ b/frontend/client/src/components/SideBar/RecentGoodsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { FaArrowUp, FaArrowDown } from 'react-icons/fa';
 import { AiFillCloseCircle } from 'react-icons/ai';
@@ -36,6 +36,10 @@ const RecentGoodsView: React.FC<SideBarProps> = ({ goodsList = [], onDeleteGoods
     onClickGoods && onClickGoods(id);
     e.stopPropagation();
   };
+
+  useEffect(() => {
+    setRecentGoodsIndx(0);
+  }, [goodsList]);
 
   return (
     <RecentGoodsViewContainer>

--- a/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
+++ b/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
@@ -7,11 +7,13 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import AddressCreateModal from '@src/components/AddressModals/AddressCreateModal/AddressCreateModal';
 import AddressManageModal from '@src/components/AddressModals/AddressManageModal/AddressManageModal';
+import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 
 const MyAddressView = () => {
   const [addresses, setAddresses] = useState<AddressInfo[]>([]);
   const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
   const [isOpenManageModal, setIsOpenManageModal] = useState(false);
+  const pushToast = usePushToast();
 
   const toggleCreateModal = () => {
     setIsOpenCreateModal(!isOpenCreateModal);
@@ -24,17 +26,17 @@ const MyAddressView = () => {
   };
 
   async function fetchAddresses() {
-    const { result } = await AddressAPI.getAddresses();
-    setAddresses(result);
+    try {
+      const { result } = await AddressAPI.getAddresses();
+      setAddresses(result);
+    } catch (err) {
+      console.error(err);
+      pushToast({ text: '사용자 주소를 불러오는데 실패했습니다. 서버오류' });
+    }
   }
 
   useEffect(() => {
-    try {
-      fetchAddresses();
-    } catch (err) {
-      console.error(err);
-      alert('사용자 주소를 불러오는데 실패했습니다. 서버오류');
-    }
+    fetchAddresses();
   }, []);
 
   const defaultAddress = addresses.find((address) => address.isDefault);

--- a/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyOrderListView/MyOrderListView.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import Topic from '@src/components/Topic/Topic';
 import Paginator from '@src/components/Paginator/Paginator';
 import OrderCard from '@src/pages/MyPage/MyOrderListView/OrderCard';
+import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 
 const DEFAULT_START_PAGE = 1; // 초기 페이지네이션 페이지.
 const LIMIT_COUNT_ORDER = 4; // 화면 사이즈를 생각했을 때 4 개가 적당합니다.
@@ -14,23 +15,26 @@ const MyOrderListView = () => {
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
   const [focusOrderId, setFocusOrderId] = useState<number>(0);
+  const pushToast = usePushToast();
 
   const handleClickOrder = (orderId: number) => {
     setFocusOrderId(orderId);
   };
 
   const fetchOrderList = async () => {
-    const { result } = await OrderAPI.getOrders({ page: currentPage, limit: LIMIT_COUNT_ORDER });
-    setOrderPaginationResult(result);
+    try {
+      const { result } = await OrderAPI.getOrders({ page: currentPage, limit: LIMIT_COUNT_ORDER });
+      setOrderPaginationResult(result);
+    } catch (err) {
+      console.error(err);
+      pushToast({
+        text: '주문정보 불러오는데 실패했습니다. 서버오류',
+      });
+    }
   };
 
   useEffect(() => {
-    try {
-      fetchOrderList();
-    } catch (err) {
-      console.error(err);
-      alert('주문정보 불러오는데 실패했습니다. 서버오류');
-    }
+    fetchOrderList();
   }, [currentPage]);
 
   return (

--- a/frontend/client/src/pages/MyPage/MyProfileView/MyProfileView.tsx
+++ b/frontend/client/src/pages/MyPage/MyProfileView/MyProfileView.tsx
@@ -6,7 +6,6 @@ import { getCarts } from '@src/apis/cartAPI';
 import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 import { getMyWishGoods } from '@src/apis/goodsAPI';
 import { getOrders } from '@src/apis/orderAPI';
-import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import { usePushHistory } from '@src/lib/CustomRouter';
 
 const MyProfileView = () => {
@@ -41,7 +40,6 @@ const MyProfileView = () => {
   };
   const fetchOrderData = async () => {
     try {
-      // TODO:(jiho) Goods 페이지네이션이랑 API 함수 인터페이스 형식 통일시켜야합니다.
       const {
         result: { meta },
       } = await getOrders({ page: 0 }); // 여기서 Page 값은 의미없음.

--- a/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
+++ b/frontend/client/src/pages/MyPage/MyWishListView/MyWishListView.tsx
@@ -3,6 +3,7 @@ import GoodsSection from '@src/components/GoodsSection/GoodsSection';
 import HighlightedText from '@src/components/HighlightedText/HighlightedText';
 import Paginator from '@src/components/Paginator/Paginator';
 import Topic from '@src/components/Topic/Topic';
+import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 import { GoodsPaginationResult } from '@src/types/Goods';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -13,19 +14,20 @@ const LIMIT_COUNT_ITEMS_IN_PAGE = 4;
 const MyWishListView = () => {
   const [goodsPaginationResult, setGoodsPaginationResult] = useState<GoodsPaginationResult>();
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
+  const pushToast = usePushToast();
 
   const fetchWishGoodsList = async () => {
-    const { result } = await getMyWishGoods({ page: currentPage, limit: LIMIT_COUNT_ITEMS_IN_PAGE });
-    setGoodsPaginationResult(result);
+    try {
+      const { result } = await getMyWishGoods({ page: currentPage, limit: LIMIT_COUNT_ITEMS_IN_PAGE });
+      setGoodsPaginationResult(result);
+    } catch (err) {
+      console.error(err);
+      pushToast({ text: '찜 리스트를 불러오는데 실패했습니다. 서버오류' });
+    }
   };
 
   useEffect(() => {
-    try {
-      fetchWishGoodsList();
-    } catch (err) {
-      console.error(err);
-      alert('찜 리스트를 불러오는데 실패했습니다. 서버오류');
-    }
+    fetchWishGoodsList();
   }, [currentPage]);
 
   return (

--- a/frontend/client/src/recoil/recentGoodsState.ts
+++ b/frontend/client/src/recoil/recentGoodsState.ts
@@ -1,0 +1,19 @@
+import { DetailGoods } from '@src/types/Goods';
+import { atom } from 'recoil';
+
+const RecentGoodsStorageKey = 'recentGoodsHistory';
+
+const makeUniqueDetailGoodsList = (goodsList: DetailGoods[]) => {
+  const idSet = new Set<number>();
+  goodsList.forEach((goods) => idSet.add(goods.id));
+  return Array.from(idSet.keys()).map((id) => goodsList.find((goods) => goods.id === id)!);
+};
+
+const originStorageValues = localStorage.getItem(RecentGoodsStorageKey);
+const initDetailGoods: DetailGoods[] = originStorageValues ? JSON.parse(originStorageValues) : [];
+const initState = makeUniqueDetailGoodsList(initDetailGoods);
+
+export const recentlyGoodsState = atom<DetailGoods[]>({
+  key: 'recentlyGoodsState',
+  default: initState,
+});

--- a/frontend/client/webpack.common.js
+++ b/frontend/client/webpack.common.js
@@ -66,7 +66,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'bundle.js',
-    publicPath: '/',
+    publicPath: '/dist',
   },
 
   plugins: [

--- a/frontend/client/webpack.common.js
+++ b/frontend/client/webpack.common.js
@@ -66,7 +66,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'bundle.js',
-    publicPath: '/dist',
+    publicPath: '/',
   },
 
   plugins: [

--- a/frontend/client/webpack.dev.js
+++ b/frontend/client/webpack.dev.js
@@ -6,8 +6,6 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
-    publicPath: '/',
     overlay: true,
     port: 8081,
     stats: 'errors-only',


### PR DESCRIPTION
## :bookmark_tabs: 제목

주문관련 API를 활용해서 실시간 주문 현황과 모든 주문 조회 탭을 만들었습니다.

기술적으로 특별한 내용은 없습니다. 주문을 보여주는 박스에서  어떤 데이터를 보여줘야하는지를 등등을 회의를 통해 다시 결정해야할 것 같습니다.


<img width="697" alt="스크린샷 2021-08-24 오전 1 18 10" src="https://user-images.githubusercontent.com/20085849/130482004-5e6647e3-a41d-45c6-97fd-5071ec221157.png">



## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역


- [x] 폴링을 위한 `useInterval` 훅 추가  [코드](https://github.com/woowa-techcamp-2021/store-5/pull/179/files#diff-3f54a1a0b96e4d6d882c0bd354d1a503f321f731dd7a96b031c82de8b40172c9R1)

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현시점에서 대시보드의 디자인에 대해 다같이 의논해봐야할 것 같습니다.