### PR TITLE
[feature/118] 프로모션 조회수 API 구현 및 클라이언트 연동

### DIFF
--- a/backend/src/controller/promotion.controller.ts
+++ b/backend/src/controller/promotion.controller.ts
@@ -25,8 +25,15 @@ async function deletePromotion(req: Request, res: Response) {
   res.sendStatus(204);
 }
 
+async function increasePromotionView(req: Request, res: Response) {
+  const promotionId = Number(req.params.id);
+  await PromotionService.increasePromotionView(promotionId);
+  res.sendStatus(204);
+}
+
 export const PromotionController = {
   createPromotion,
   getPromotions,
   deletePromotion,
+  increasePromotionView,
 };

--- a/backend/src/entity/Promotion.ts
+++ b/backend/src/entity/Promotion.ts
@@ -17,6 +17,9 @@ export class Promotion {
   @Column({ type: 'varchar', length: 400 })
   imgUrl: string;
 
+  @Column({ type: 'int' })
+  view: number;
+
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
 

--- a/backend/src/entity/Promotion.ts
+++ b/backend/src/entity/Promotion.ts
@@ -17,7 +17,7 @@ export class Promotion {
   @Column({ type: 'varchar', length: 400 })
   imgUrl: string;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'int', default: 0 })
   view: number;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/backend/src/repository/promotion.repository.ts
+++ b/backend/src/repository/promotion.repository.ts
@@ -1,4 +1,4 @@
-import { DeleteResult, getRepository } from 'typeorm';
+import { DeleteResult, getRepository, UpdateResult } from 'typeorm';
 import { PROMOTION_DB_ERROR } from '../constants/database.error.name';
 import { Promotion } from '../entity/Promotion';
 import { DatabaseError } from '../errors/base.error';
@@ -36,8 +36,23 @@ async function deletePromotion(promotionId: number): Promise<DeleteResult> {
   }
 }
 
+async function increasePromotionView(promotionId: number): Promise<UpdateResult> {
+  try {
+    return await getRepository(Promotion)
+      .createQueryBuilder()
+      .update('promotion')
+      .where(`promotion.id = ${promotionId}`)
+      .set({ view: () => 'view + 1' })
+      .execute();
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(PROMOTION_DB_ERROR);
+  }
+}
+
 export const PromotionRepository = {
   createPromotion,
   getPromotions,
   deletePromotion,
+  increasePromotionView,
 };

--- a/backend/src/router/promotion.router.ts
+++ b/backend/src/router/promotion.router.ts
@@ -15,4 +15,6 @@ router.get('/', wrapAsync(PromotionController.getPromotions));
 router.post('/', uploadProductFiles.single('file'), wrapAsync(PromotionController.createPromotion));
 router.delete('/:id', checkNumberInParams, wrapAsync(PromotionController.deletePromotion));
 
+router.patch('/:id', checkNumberInParams, wrapAsync(PromotionController.increasePromotionView));
+
 export default router;

--- a/backend/src/service/promotion.service.ts
+++ b/backend/src/service/promotion.service.ts
@@ -1,5 +1,5 @@
 import { GoodsRepository } from './../repository/goods.repository';
-import { DeleteResult } from 'typeorm';
+import { DeleteResult, UpdateResult } from 'typeorm';
 import { BadRequestError } from '../errors/client.error';
 import { PromotionRepository } from '../repository/promotion.repository';
 import { CreatePromotionBody } from '../types/request/promotion.request';
@@ -31,6 +31,10 @@ async function deletePromotion(promotionId: number): Promise<DeleteResult> {
   return await PromotionRepository.deletePromotion(promotionId);
 }
 
+async function increasePromotionView(promotionId: number): Promise<UpdateResult> {
+  return await PromotionRepository.increasePromotionView(promotionId);
+}
+
 async function checkValidateCreatePromotion(body: CreatePromotionBody, imgUrl: string): Promise<void> {
   const { goodsId } = body;
   const foundGoods = await GoodsRepository.findGoodsById(goodsId);
@@ -42,4 +46,5 @@ export const PromotionService = {
   createPromotion,
   getPromotions,
   deletePromotion,
+  increasePromotionView,
 };

--- a/frontend/client/src/apis/promotionAPI.ts
+++ b/frontend/client/src/apis/promotionAPI.ts
@@ -1,10 +1,25 @@
 import { Promotion } from '@src/types/Promotion';
 import { APIResponse, checkedFetch } from './base';
 
-export const getPromotions = async (): Promise<APIResponse<Promotion[]>> => {
+const getPromotions = async (): Promise<APIResponse<Promotion[]>> => {
   const res = await checkedFetch(`/api/promotion`, {
     method: 'GET',
     credentials: 'include',
   });
   return await res.json();
 };
+
+// 결과를 반환할 필요가 없으므로 return void
+const increasePromotionView = async (promotionId: number): Promise<void> => {
+  await checkedFetch(`/api/promotion/${promotionId}`, {
+    method: 'PATCH',
+    credentials: 'include',
+  });
+};
+
+const PromotionAPI = {
+  getPromotions,
+  increasePromotionView,
+};
+
+export default PromotionAPI;

--- a/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
+++ b/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import { Promotion } from '@src/types/Promotion';
+import { usePushHistory } from '@src/lib/CustomRouter';
+import PromotionAPI from '@src/apis/promotionAPI';
+import PromotionCarouselImage from '@src/components/PromotionCarousel/PromotionCarouselImage/PromotionCarouselImage';
 
 interface Props {
   promotions: Promotion[];
@@ -22,11 +25,17 @@ const SLIDE_SETTING = {
 
 // TODO:(jiho) Promotion 타입에 fetchURL이 있어야하지않을가? 항상 상품 상세화면으로 가야하나? 아니면 다른 화면으로 갈 수 있지않을까?
 const PromotionCarousel: React.FC<Props> = ({ promotions }) => {
+  const push = usePushHistory();
+  const handleClickGoodsItem = (promotionId: number) => {
+    PromotionAPI.increasePromotionView(promotionId);
+    push('/detail/' + promotionId);
+  };
+
   return (
     <PromotionCarouselContainer>
       <Slider {...SLIDE_SETTING}>
         {promotions.map(({ id, imgUrl }) => (
-          <PromotionImage key={id} src={imgUrl} />
+          <PromotionImage key={id} src={imgUrl} data-id={id} onClick={() => handleClickGoodsItem(id)} />
         ))}
       </Slider>
     </PromotionCarouselContainer>
@@ -36,6 +45,13 @@ const PromotionCarousel: React.FC<Props> = ({ promotions }) => {
 const PromotionCarouselContainer = styled.div`
   width: 100%;
   overflow: hidden;
+  /* 
+    slick 슬라이더의 마지막 슬라이드가 상단에 위치하여 마지막 슬라이드만 onClick이 발생하는 문제가 있었습니다!
+    하여 활성화된 슬라이더의 z-index를 1로 설정하였습니다.
+  */
+  .slick-active {
+    z-index: 1;
+  }
 `;
 
 const PromotionImage = styled.img`
@@ -43,6 +59,7 @@ const PromotionImage = styled.img`
   user-select: none;
   object-fit: contain;
   outline: none;
+  cursor: pointer;
 `;
 
 export default PromotionCarousel;

--- a/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
+++ b/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
@@ -6,7 +6,6 @@ import 'slick-carousel/slick/slick-theme.css';
 import { Promotion } from '@src/types/Promotion';
 import { usePushHistory } from '@src/lib/CustomRouter';
 import PromotionAPI from '@src/apis/promotionAPI';
-import PromotionCarouselImage from '@src/components/PromotionCarousel/PromotionCarouselImage/PromotionCarouselImage';
 
 interface Props {
   promotions: Promotion[];

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -1,23 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { MainGoodsListResult, ThumbnailGoods } from '@src/types/Goods';
+import { MainGoodsListResult } from '@src/types/Goods';
 import GoodsSection from '@src/components/GoodsSection/GoodsSection';
 import PromotionCarousel from '@src/components/PromotionCarousel/PromotionCarousel';
 import { Promotion } from '@src/types/Promotion';
 import { getMainGoodsListMap } from '@src/apis/goodsAPI';
-import { getPromotions } from '@src/apis/promotionAPI';
+import PromotionAPI from '@src/apis/promotionAPI';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@src/recoil/userState';
-
-import SideBar from '@src/components/SideBar/SideBar';
-import Footer from '@src/components/Footer/Footer';
 
 const Main = () => {
   const [promotions, setPromotions] = useState<Promotion[]>([]);
   const userRecoil = useRecoilValue(userState);
 
   const fetchPromotions = async () => {
-    const { result } = await getPromotions();
+    const { result } = await PromotionAPI.getPromotions();
     setPromotions(result);
   };
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

프로모션 조회수 API 구현 및 클라이언트 연동

### 조회수 7 -> 8 정상 증가
![녹화_2021_08_24_01_29_05_143](https://user-images.githubusercontent.com/45394360/130483440-ee546afb-ad5c-4e9c-963c-47073aa6dd81.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 개발 환경 실행 및 build, test가 정상적이었나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 프로모션 조회수 증가를 위한 엔티티 수정
- [x] 프로모션 조회수 증가 관련 API 기능 구현
- [x] 프로모션 조회수 증가 적용

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- slick 클릭 이벤트 z-index 이슈를 css 클래스 선택자로 해결했습니다.
