### PR TITLE
[feature/173] Client Header에서 장바구니 개수를 렌더링

### DIFF
--- a/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/IconContainerStyle.ts
+++ b/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/IconContainerStyle.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const IconContainer = styled.div`
+  position: relative;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -15,4 +16,17 @@ export const IconTitle = styled.span`
   font-size: 0.7rem;
   margin-top: 6px;
   color: gray;
+`;
+
+export const IconNumber = styled.span`
+  position: absolute;
+  top: 0;
+  right: 0.75rem;
+  color: white;
+  background-color: ${(prop) => prop.theme.primary};
+  width: 0.75rem;
+  height: 0.75rem;
+  text-align: center;
+  font-size: 0.75rem;
+  border-radius: 100%;
 `;

--- a/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/ShoppigCartIcon/ShoppingCartIcon.tsx
+++ b/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/ShoppigCartIcon/ShoppingCartIcon.tsx
@@ -29,6 +29,11 @@ const ShoppingCartIcon = () => {
   }, [setOpenLoginModal]);
 
   useEffect(() => {
+    if (!userRecoil.isLoggedIn) {
+      setCartGoodsList([]);
+      return;
+    }
+
     const fetchCarts = async () => {
       const { result } = await getCarts();
       setCartGoodsList(result);

--- a/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/ShoppigCartIcon/ShoppingCartIcon.tsx
+++ b/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/ShoppigCartIcon/ShoppingCartIcon.tsx
@@ -1,16 +1,20 @@
+import { getCarts } from '@src/apis/cartAPI';
 import { usePushHistory } from '@src/lib/CustomRouter';
 import LoginModal from '@src/portal/LoginModal/LoginModal';
+import { cartState } from '@src/recoil/cartState';
 import { userState } from '@src/recoil/userState';
 import React, { useCallback } from 'react';
+import { useEffect } from 'react';
 import { useState } from 'react';
 import { AiOutlineShoppingCart } from 'react-icons/ai';
-import { useRecoilValue } from 'recoil';
-import { IconContainer, IconTitle } from '../IconContainerStyle';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { IconContainer, IconNumber, IconTitle } from '../IconContainerStyle';
 
 const ShoppingCartIcon = () => {
   const push = usePushHistory();
   const [openLoginModal, setOpenLoginModal] = useState<boolean>(false);
   const userRecoil = useRecoilValue(userState);
+  const [cartGoodsList, setCartGoodsList] = useRecoilState(cartState);
 
   const handlePushCart = useCallback(() => {
     push('/cart');
@@ -23,9 +27,20 @@ const ShoppingCartIcon = () => {
   const handleCloseModal = useCallback(() => {
     setOpenLoginModal(false);
   }, [setOpenLoginModal]);
+
+  useEffect(() => {
+    const fetchCarts = async () => {
+      const { result } = await getCarts();
+      setCartGoodsList(result);
+    };
+
+    fetchCarts();
+  }, [userRecoil]);
+
   return (
     <IconContainer onClick={userRecoil.isLoggedIn ? handlePushCart : handleOpenModal}>
       <AiOutlineShoppingCart size='1.5em' />
+      {cartGoodsList.length > 0 && <IconNumber>{cartGoodsList.length}</IconNumber>}
       <IconTitle>장바구니</IconTitle>
       {openLoginModal && <LoginModal onClose={handleCloseModal} />}
     </IconContainer>

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -2,12 +2,14 @@ import { deleteCarts, getCarts, updateCart } from '@src/apis/cartAPI';
 import PageHeader from '@src/components/PageHeader/PageHeader';
 import usePushToOrderPage from '@src/hooks/usePushToOrderPage';
 import { usePushHistory } from '@src/lib/CustomRouter';
+import { cartState } from '@src/recoil/cartState';
 import { CartGoods } from '@src/types/Goods';
 import composeComponent from '@src/utils/composeComponent';
 import withLoggedIn from '@src/utils/withLoggedIn';
 import withScrollToTopOnMount from '@src/utils/withScrollToTopOnMount';
 import React, { useCallback, useState } from 'react';
 import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 import CartGoodsListContainer from './CartGoodsListContainer/CartGoodsListContainer';
 import CartOrder from './CartOrder/CartOrder';
 import EmptyCart from './EmptyCart/EmptyCart';
@@ -15,7 +17,7 @@ import Layout from './Layout/Layout';
 
 const CartPage: React.FC = () => {
   const pushToOrderPage = usePushToOrderPage();
-  const [cartGoodsList, setCartGoodsList] = useState<CartGoods[]>([]);
+  const [cartGoodsList, setCartGoodsList] = useRecoilState(cartState);
   const [isCartsFetched, setIsCartsFetched] = useState(false);
 
   const handleDeleteCartGoodsAll = useCallback(

--- a/frontend/client/src/recoil/cartState.ts
+++ b/frontend/client/src/recoil/cartState.ts
@@ -1,0 +1,7 @@
+import { CartGoods } from '@src/types/Goods';
+import { atom } from 'recoil';
+
+export const cartState = atom<CartGoods[]>({
+  key: 'cartState',
+  default: [],
+});


### PR DESCRIPTION
## :bookmark_tabs: Client Header에서 장바구니 개수를 렌더링


https://user-images.githubusercontent.com/64543699/130531664-7aaa5217-a770-4030-bca9-9124b50c37b7.mov



## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] cart recoil state 생성
- [x] 기존 CartList의 state를 리코일 state로 변경
- [x] 헤더에서 리코일 cart state로 장바구니 개수 렌더링

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 헤더와 장바구니 페이지의 데이터 일관성을 맞추기 위해 장바구니 상태를 리코일로 관리하게 하였습니다.
