### PR TITLE
[feature/169] 대시보드 - Bar chart, Top Selling Category (컴포넌트 API 개발) , 제품 조회수 Column 추가 및 적용

### DIFF
--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -24,8 +24,14 @@ async function getParentCategoryCount(req: Request, res: Response) {
   res.status(200).json({ result });
 }
 
+async function getTopSellingCategory(req: Request, res: Response) {
+  const result = await CategoryService.getTopSellingCategory();
+  res.status(200).json({ result });
+}
+
 export default {
   createCategory,
   getAllCategory,
   getParentCategoryCount,
+  getTopSellingCategory,
 };

--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -31,6 +31,7 @@ async function getTopSellingCategory(req: Request, res: Response) {
 
 async function getCategoryViews(req: Request, res: Response) {
   const result = await CategoryService.getCategoryViews();
+  res.status(200).json({ result });
 }
 
 export default {

--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -29,9 +29,14 @@ async function getTopSellingCategory(req: Request, res: Response) {
   res.status(200).json({ result });
 }
 
+async function getCategoryViews(req: Request, res: Response) {
+  const result = await CategoryService.getCategoryViews();
+}
+
 export default {
   createCategory,
   getAllCategory,
   getParentCategoryCount,
   getTopSellingCategory,
+  getCategoryViews,
 };

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -155,6 +155,7 @@ async function createDefaultGoods() {
         id: delivery,
       },
       countOfSell,
+      view: Math.random() * 100,
     });
     await getRepository(GoodsImg).save({ goods: { id: newGoods.id }, url: goods.thumbnailUrl });
     console.log(`초기 상품 데이터 삽입 : name - ${newGoods.title}, id - ${newGoods.id}`);

--- a/backend/src/entity/Goods.ts
+++ b/backend/src/entity/Goods.ts
@@ -35,6 +35,9 @@ export class Goods {
   @Column({ type: 'int', default: 0 })
   countOfSell: number;
 
+  @Column({ type: 'int', default: 0 })
+  view: number;
+
   @Column({ type: 'varchar', length: 5 })
   state: string;
 

--- a/backend/src/repository/category.repository.ts
+++ b/backend/src/repository/category.repository.ts
@@ -61,9 +61,18 @@ async function getParentCategories(): Promise<Category[]> {
   }
 }
 
-async function getCategoryCountByParentId(parentId: number):Promise<number> {
+async function getCategoryCountByParentId(parentId: number): Promise<number> {
   try {
     return getRepository(Category).count({ where: { parent: parentId } });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(CATEGORY_DB_ERROR);
+  }
+}
+
+async function getParentCategoryNameById(categoryId: number): Promise<Category | undefined> {
+  try {
+    return getRepository(Category).findOne({ select: ['name'], where: { id: categoryId } });
   } catch (err) {
     console.error(err);
     throw new DatabaseError(CATEGORY_DB_ERROR);
@@ -77,4 +86,5 @@ export const CategoryRepository = {
   getAllCategories,
   getParentCategories,
   getCategoryCountByParentId,
+  getParentCategoryNameById,
 };

--- a/backend/src/repository/category.repository.ts
+++ b/backend/src/repository/category.repository.ts
@@ -79,6 +79,15 @@ async function getParentCategoryNameById(categoryId: number): Promise<Category |
   }
 }
 
+async function getCategoryNameById(categoryId: number): Promise<Category | undefined> {
+  try {
+    return getRepository(Category).findOne({ select: ['name'], where: { id: categoryId } });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(CATEGORY_DB_ERROR);
+  }
+}
+
 export const CategoryRepository = {
   createCategory,
   createSubCategory,
@@ -87,4 +96,5 @@ export const CategoryRepository = {
   getParentCategories,
   getCategoryCountByParentId,
   getParentCategoryNameById,
+  getCategoryNameById,
 };

--- a/backend/src/repository/goods.repository.ts
+++ b/backend/src/repository/goods.repository.ts
@@ -186,7 +186,7 @@ async function findBestSellingGoods(limit: number): Promise<Goods[]> {
   }
 }
 
-async function plusGoodsViewById(goodsId: number): Promise<void> {
+async function increaseGoodsViewById(goodsId: number): Promise<void> {
   try {
     await getRepository(Goods).increment({ id: goodsId }, 'view', 1);
   } catch (err) {
@@ -206,5 +206,5 @@ export const GoodsRepository = {
   findStockById,
   findBestSellingGoods,
   searchGoodsFromKeyword,
-  plusGoodsViewById,
+  increaseGoodsViewById,
 };

--- a/backend/src/repository/goods.repository.ts
+++ b/backend/src/repository/goods.repository.ts
@@ -31,6 +31,17 @@ async function findGoodsDetailById(goodsId: number): Promise<Goods | undefined> 
   }
 }
 
+async function findAllWithCategory(): Promise<Goods[]> {
+  try {
+    return await getRepository(Goods).find({
+      relations: ['category'],
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(GOODS_DB_ERROR);
+  }
+}
+
 async function findAllByOption({
   offset,
   limit,
@@ -159,9 +170,11 @@ async function findBestSellingGoods(limit: number): Promise<Goods[]> {
     take: limit,
   });
 }
+
 export const GoodsRepository = {
   findGoodsById,
   findGoodsDetailById,
+  findAllWithCategory,
   findAllByOption,
   findAllWishByUserId,
   findTotalCountByOption,

--- a/backend/src/repository/goods.repository.ts
+++ b/backend/src/repository/goods.repository.ts
@@ -145,30 +145,54 @@ async function findSellCountAverage(): Promise<number> {
 }
 
 async function searchGoodsFromKeyword(keyword: string): Promise<SearchedGoodsFromKeyword[]> {
-  const goodsRepo = getRepository(Goods);
-  return await goodsRepo.find({
-    select: ['id', 'thumbnailUrl', 'title'],
-    where: { title: Like(`%${keyword}%`) },
-    take: AUTO_SEARCH_GOODS_NUMBER,
-  });
+  try {
+    const goodsRepo = getRepository(Goods);
+    return await goodsRepo.find({
+      select: ['id', 'thumbnailUrl', 'title'],
+      where: { title: Like(`%${keyword}%`) },
+      take: AUTO_SEARCH_GOODS_NUMBER,
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(GOODS_DB_ERROR);
+  }
 }
 
 async function findStockById(goodsId: number): Promise<number> {
-  const goodsRepo = getRepository(Goods);
-  const goods = await goodsRepo.findOne({
-    select: ['stock'],
-    where: { id: goodsId },
-  });
-  return goods?.stock ?? 0;
+  try {
+    const goodsRepo = getRepository(Goods);
+    const goods = await goodsRepo.findOne({
+      select: ['stock'],
+      where: { id: goodsId },
+    });
+    return goods?.stock ?? 0;
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(GOODS_DB_ERROR);
+  }
 }
 
 async function findBestSellingGoods(limit: number): Promise<Goods[]> {
-  return getRepository(Goods).find({
-    order: {
-      countOfSell: 'DESC',
-    },
-    take: limit,
-  });
+  try {
+    return getRepository(Goods).find({
+      order: {
+        countOfSell: 'DESC',
+      },
+      take: limit,
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(GOODS_DB_ERROR);
+  }
+}
+
+async function plusGoodsViewById(goodsId: number): Promise<void> {
+  try {
+    await getRepository(Goods).increment({ id: goodsId }, 'view', 1);
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(GOODS_DB_ERROR);
+  }
 }
 
 export const GoodsRepository = {
@@ -182,4 +206,5 @@ export const GoodsRepository = {
   findStockById,
   findBestSellingGoods,
   searchGoodsFromKeyword,
+  plusGoodsViewById,
 };

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -7,5 +7,6 @@ const router = express.Router();
 router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
 router.get('/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
+router.get('/dashboard/sell', wrapAsync(CategoryController.getTopSellingCategory));
 
 export default router;

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -8,5 +8,6 @@ router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
 router.get('/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
 router.get('/dashboard/sell', wrapAsync(CategoryController.getTopSellingCategory));
+router.get('/dashboard/view', wrapAsync(CategoryController.getCategoryViews));
 
 export default router;

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -7,6 +7,8 @@ import {
 } from '../types/response/category.response';
 import { CategoryRepository } from '../repository/category.repository';
 
+const BEST_LIST_LENGTH = 5;
+
 async function createCategory(name: string, parentId?: number): Promise<Category> {
   if (parentId) {
     return await CategoryRepository.createSubCategory(name, parentId);
@@ -72,8 +74,24 @@ async function getTopSellingCategory(): Promise<CategorySellCountResponse> {
     result.push({ name: key, total: categories[key] });
   }
   result.sort((a, b) => b.total - a.total);
-  const MAX_END = result.length > 5 ? 5 : result.length;
+  const MAX_END = result.length > BEST_LIST_LENGTH ? BEST_LIST_LENGTH : result.length;
   return result.slice(0, MAX_END);
+}
+
+async function getCategoryViews() {
+  const result = [];
+  const categories: {
+    [key: string]: number;
+  } = {};
+  const goods = await GoodsRepository.findAllWithCategory();
+  // category parentId를 key로 조회 수 총합을 구합니다.
+  goods.forEach((item) => {
+    if (categories[item.category.parent]) {
+      categories[item.category.parent] += item.view;
+    } else {
+      categories[item.category.parent] = item.view;
+    }
+  });
 }
 
 async function pushCategoryCountToList(category: Category, categoryCountList: CategoryCountResponse): Promise<void> {
@@ -89,4 +107,5 @@ export default {
   getAllCategory,
   getParentCategoryCount,
   getTopSellingCategory,
+  getCategoryViews,
 };

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -95,9 +95,7 @@ async function getCategoryViews(): Promise<CategoryViewCountResponse> {
       categories[item.category.parent] = item.view;
     }
   });
-  await Promise.all(
-    Object.keys(categories).map(async (key) => pushCategoryViewToList(Number(key), categories[key], result))
-  );
+  await Promise.all(Object.keys(categories).map((key) => pushCategoryViewToList(Number(key), categories[key], result)));
   return result;
 }
 

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -150,6 +150,7 @@ async function getDetailById(goodsId: number, userId?: number): Promise<DetailGo
   if (data && userId) {
     res.isWish = (await WishRepository.findWishCountByGoodsIdAndUserId(goodsId, userId)) > 0;
   }
+  await GoodsRepository.plusGoodsViewById(goodsId);
   return { ...res, goodsImgs: imgs };
 }
 

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -150,7 +150,7 @@ async function getDetailById(goodsId: number, userId?: number): Promise<DetailGo
   if (data && userId) {
     res.isWish = (await WishRepository.findWishCountByGoodsIdAndUserId(goodsId, userId)) > 0;
   }
-  await GoodsRepository.plusGoodsViewById(goodsId);
+  await GoodsRepository.increaseGoodsViewById(goodsId);
   return { ...res, goodsImgs: imgs };
 }
 

--- a/backend/src/types/response/category.response.ts
+++ b/backend/src/types/response/category.response.ts
@@ -8,8 +8,14 @@ type CategorySellCount = {
   total: number;
 };
 
+type CategoryViewCount = {
+  name: string;
+  view: number;
+};
+
 export type CategoryCountResponse = CategoryCount[];
 export type CategorySellCountResponse = CategorySellCount[];
+export type CategoryViewCountResponse = CategoryViewCount[];
 
 export type CategoryResponse = {
   id: number;

--- a/backend/src/types/response/category.response.ts
+++ b/backend/src/types/response/category.response.ts
@@ -3,7 +3,13 @@ type CategoryCount = {
   value: number;
 };
 
+type CategorySellCount = {
+  name: string;
+  total: number;
+};
+
 export type CategoryCountResponse = CategoryCount[];
+export type CategorySellCountResponse = CategorySellCount[];
 
 export type CategoryResponse = {
   id: number;

--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -12,9 +12,6 @@ export default function App() {
     <>
       <Router>
         <Header />
-        <Route path='/'>
-          <Main />
-        </Route>
         <Routes>
           <Route path='/admin/goods'>
             <GoodsAdmin />

--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -12,6 +12,9 @@ export default function App() {
     <>
       <Router>
         <Header />
+        <Route path='/'>
+          <Main />
+        </Route>
         <Routes>
           <Route path='/admin/goods'>
             <GoodsAdmin />

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -1,4 +1,4 @@
-import { Category } from '@src/types/Category';
+import { BestSelledCategory, Category } from '@src/types/Category';
 import { PieChartData } from '@src/types/Chart';
 import { APIResponse, checkedFetch } from './base';
 interface CategoryResponse {
@@ -20,9 +20,18 @@ const getParentCategoryCount = async (): Promise<APIResponse<PieChartData>> => {
   return res.json();
 };
 
+const getBestSellingCategory = async (): Promise<APIResponse<BestSelledCategory[]>> => {
+  const res = await checkedFetch(`/api/category/dashboard/sell`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return res.json();
+};
+
 const CategoryAPI = {
   getAllCategory,
   getParentCategoryCount,
+  getBestSellingCategory,
 };
 
 export default CategoryAPI;

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -1,4 +1,4 @@
-import { BestSelledCategory, Category } from '@src/types/Category';
+import { BestSelledCategory, Category, CategoryView } from '@src/types/Category';
 import { PieChartData } from '@src/types/Chart';
 import { APIResponse, checkedFetch } from './base';
 interface CategoryResponse {
@@ -28,10 +28,19 @@ const getBestSellingCategory = async (): Promise<APIResponse<BestSelledCategory[
   return res.json();
 };
 
+const getCategoriesView = async (): Promise<APIResponse<CategoryView[]>> => {
+  const res = await checkedFetch(`/api/category/dashboard/view`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return res.json();
+};
+
 const CategoryAPI = {
   getAllCategory,
   getParentCategoryCount,
   getBestSellingCategory,
+  getCategoriesView,
 };
 
 export default CategoryAPI;

--- a/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
@@ -47,8 +47,8 @@ const CategoryBarChart = () => {
           <YAxis />
           <Tooltip />
           <Legend />
-          <Bar dataKey='view' barSize={20} fill='#413ea0' />
-          <Line type='monotone' dataKey='view' stroke='#ff7300' />
+          <Bar dataKey='view' barSize={20} fill={theme.ChartColorRed} />
+          <Line type='monotone' dataKey='view' stroke={theme.ChartColorPurple} />
         </ComposedChart>
       </ResponsiveContainer>
     </CategoryBarContainer>

--- a/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
@@ -1,0 +1,84 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import { theme } from '@src/theme/theme';
+import React from 'react';
+import {
+  ComposedChart,
+  Line,
+  Area,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+const CategoryBarChart = () => {
+  const data = [
+    {
+      name: 'Cate A',
+      조회수: 590,
+    },
+    {
+      name: 'Cate B',
+      조회수: 868,
+    },
+    {
+      name: 'Cate C',
+      조회수: 1397,
+    },
+    {
+      name: 'Cate D',
+      조회수: 1480,
+    },
+    {
+      name: 'Cate E',
+      조회수: 1520,
+    },
+    {
+      name: 'Cate F',
+      조회수: 1400,
+    },
+  ];
+  return (
+    <CategoryBarContainer>
+      <BarChartTitle color={theme.greenColor}>카테고리 조회 수</BarChartTitle>
+      <ResponsiveContainer width='100%' height='95%'>
+        <ComposedChart
+          data={data}
+          margin={{
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+          }}
+        >
+          <CartesianGrid stroke='#f5f5f5' />
+          <XAxis dataKey='name' scale='band' fontSize='0.7em' />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey='조회수' barSize={20} fill='#413ea0' />
+          <Line type='monotone' dataKey='조회수' stroke='#ff7300' />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </CategoryBarContainer>
+  );
+};
+
+const CategoryBarContainer = styled('div')`
+  padding: 16px;
+  width: 50%;
+  height: 100%;
+  background-color: whitesmoke;
+  border-radius: 16px;
+  margin-right: 16px;
+`;
+
+const BarChartTitle = styled('div')<{ color: string }>`
+  margin-bottom: 16px;
+  color: ${(props) => props.color};
+  font-weight: 700;
+`;
+export default CategoryBarChart;

--- a/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
@@ -1,6 +1,8 @@
+import CategoryAPI from '@src/apis/categoryAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import { theme } from '@src/theme/theme';
-import React from 'react';
+import { CategoryView } from '@src/types/Category';
+import React, { useEffect, useState } from 'react';
 import {
   ComposedChart,
   Line,
@@ -15,38 +17,24 @@ import {
 } from 'recharts';
 
 const CategoryBarChart = () => {
-  const data = [
-    {
-      name: 'Cate A',
-      조회수: 590,
-    },
-    {
-      name: 'Cate B',
-      조회수: 868,
-    },
-    {
-      name: 'Cate C',
-      조회수: 1397,
-    },
-    {
-      name: 'Cate D',
-      조회수: 1480,
-    },
-    {
-      name: 'Cate E',
-      조회수: 1520,
-    },
-    {
-      name: 'Cate F',
-      조회수: 1400,
-    },
-  ];
+  const [categoryViews, setCategoryViews] = useState<CategoryView[]>([]);
+  useEffect(() => {
+    async function fetchCategoryViews() {
+      try {
+        const { result } = await CategoryAPI.getCategoriesView();
+        setCategoryViews(result);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchCategoryViews();
+  }, []);
   return (
     <CategoryBarContainer>
       <BarChartTitle color={theme.greenColor}>카테고리 조회 수</BarChartTitle>
       <ResponsiveContainer width='100%' height='95%'>
         <ComposedChart
-          data={data}
+          data={categoryViews}
           margin={{
             top: 10,
             right: 10,
@@ -59,8 +47,8 @@ const CategoryBarChart = () => {
           <YAxis />
           <Tooltip />
           <Legend />
-          <Bar dataKey='조회수' barSize={20} fill='#413ea0' />
-          <Line type='monotone' dataKey='조회수' stroke='#ff7300' />
+          <Bar dataKey='view' barSize={20} fill='#413ea0' />
+          <Line type='monotone' dataKey='view' stroke='#ff7300' />
         </ComposedChart>
       </ResponsiveContainer>
     </CategoryBarContainer>

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { styled } from '@src/lib/CustomStyledComponent';
 import TopSellingGoodsList from '@src/pages/Main/TopSellingGoodsList/TopSellingGoodsList';
 import CategoryPieChart from '@src/pages/Main/CategoryPieChart/CategoryPieChart';
 import LiveOrderList from '@src/pages/Main/LiveOrderList/LiveOrderList';
+import TopSellingCategoryList from '@src/pages/Main/TopSellingCategoryList/TopSellingCategoryList';
+import CategoryBarChart from '@src/pages/Main/CategoryBarChart/CategoryBarChart';
 
 const Main = () => {
   return (
@@ -12,7 +14,10 @@ const Main = () => {
           <CategoryPieChart />
           <TopSellingGoodsList />
         </LeftTopContainer>
-        <div>왼쪽 하단</div>
+        <LeftBottomContainer>
+          <CategoryBarChart />
+          <TopSellingCategoryList />
+        </LeftBottomContainer>
       </LeftContainer>
       <RightContainer>
         <LiveOrderList />
@@ -34,13 +39,20 @@ const LeftContainer = styled('div')`
   flex-direction: column;
   position: relative;
   width: 60%;
-  height: 50%;
+  height: 100%;
 `;
 
 const LeftTopContainer = styled('div')`
   display: flex;
   width: 100%;
-  height: 100%;
+  height: 50%;
+  margin-bottom: 16px;
+`;
+
+const LeftBottomContainer = styled('div')`
+  display: flex;
+  width: 100%;
+  height: 50%;
 `;
 
 const RightContainer = styled('div')`

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -46,7 +46,7 @@ const LeftTopContainer = styled('div')`
   display: flex;
   width: 100%;
   height: 50%;
-  margin-bottom: 16px;
+  padding-bottom: 16px;
 `;
 
 const LeftBottomContainer = styled('div')`

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
@@ -1,0 +1,60 @@
+import { theme } from '@src/theme/theme';
+import convertCountOfSell from '@src/utils/convertCountOfSell';
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+  category: { name: string; total: number };
+  rank: number;
+}
+
+const TopSellingCategory: React.FC<Props> = ({ category, rank }) => {
+  const BGCOLOR = [theme.GOLD, theme.SILVER, theme.BRONZE, theme.LIGHTGRAY, theme.LIGHTGRAY];
+  return (
+    <TopSellingCategoryContainer>
+      <TopSellingInfoContainer>
+        <TopSellingRank bgcolor={BGCOLOR[rank - 1]}>{rank}</TopSellingRank>
+        <TopSellingCategoryTitle>{category.name}</TopSellingCategoryTitle>
+      </TopSellingInfoContainer>
+      <TopSellingCategoryCountContainer color={theme.greenColor}>
+        <TopSellingCategoryCount>{convertCountOfSell(category.total)}</TopSellingCategoryCount>
+      </TopSellingCategoryCountContainer>
+    </TopSellingCategoryContainer>
+  );
+};
+
+const TopSellingCategoryContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TopSellingInfoContainer = styled.div`
+  display: flex;
+  font-size: 1.1em;
+`;
+
+const TopSellingRank = styled.div<{ bgcolor: string }>`
+  margin-right: 24px;
+  background-color: ${(props) => props.bgcolor};
+  color: #fff;
+  width: 2em;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 2em;
+`;
+const TopSellingCategoryTitle = styled.p`
+  display: flex;
+  align-items: center;
+`;
+
+const TopSellingCategoryCountContainer = styled.div<{ color: string }>`
+  padding: 0.5em;
+  background-color: ${(props) => props.color};
+  border-radius: 12px;
+`;
+const TopSellingCategoryCount = styled.span`
+  color: #fff;
+`;
+
+export default TopSellingCategory;

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
@@ -1,16 +1,19 @@
+import CategoryAPI from '@src/apis/categoryAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import TopSellingCategory from '@src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory';
 import { theme } from '@src/theme/theme';
-import React from 'react';
+import { BestSelledCategory } from '@src/types/Category';
+import React, { useEffect, useState } from 'react';
 
 const TopSellingCategoryList = () => {
-  const mock = [
-    { name: '잡화', total: 5000 },
-    { name: '문구', total: 3000 },
-    { name: '생필품', total: 4000 },
-    { name: '에디션', total: 2000 },
-    { name: '굿즈', total: 1000 },
-  ];
+  const [categories, setCategories] = useState<BestSelledCategory[]>([]);
+  useEffect(() => {
+    async function fetchingCategories() {
+      const { result } = await CategoryAPI.getBestSellingCategory();
+      setCategories(result);
+    }
+    fetchingCategories();
+  }, []);
 
   return (
     <TopSellingContainer>
@@ -19,7 +22,7 @@ const TopSellingCategoryList = () => {
         <TopSellingTitle color={theme.greenColor}>판매량</TopSellingTitle>
       </TopSellingTitleContainer>
       <CategoriesContainer>
-        {mock.map((category, i) => (
+        {categories.map((category, i) => (
           <TopSellingCategory key={category.name} rank={i + 1} category={category} />
         ))}
       </CategoriesContainer>

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
@@ -1,0 +1,60 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import TopSellingCategory from '@src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory';
+import { theme } from '@src/theme/theme';
+import React from 'react';
+
+const TopSellingCategoryList = () => {
+  const mock = [
+    { name: '잡화', total: 5000 },
+    { name: '문구', total: 3000 },
+    { name: '생필품', total: 4000 },
+    { name: '에디션', total: 2000 },
+    { name: '굿즈', total: 1000 },
+  ];
+
+  return (
+    <TopSellingContainer>
+      <TopSellingTitleContainer>
+        <TopSellingTitle color={theme.greenColor}>Top Selling Categories</TopSellingTitle>
+        <TopSellingTitle color={theme.greenColor}>판매량</TopSellingTitle>
+      </TopSellingTitleContainer>
+      <CategoriesContainer>
+        {mock.map((category, i) => (
+          <TopSellingCategory key={category.name} rank={i + 1} category={category} />
+        ))}
+      </CategoriesContainer>
+    </TopSellingContainer>
+  );
+};
+
+const TopSellingContainer = styled('div')`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  height: 100%;
+  padding: 16px;
+  background-color: whitesmoke;
+  border-radius: 16px;
+`;
+
+const TopSellingTitleContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const TopSellingTitle = styled('span')<{ color: string }>`
+  color: ${(props) => props.color};
+  height: 1.5em;
+  font-weight: 700;
+  margin-bottom: 16px;
+`;
+
+const CategoriesContainer = styled('div')`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  height: 100%;
+`;
+export default TopSellingCategoryList;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
@@ -71,7 +71,9 @@ const PromotionDeleteButton = styled('button')<{ bgcolor: string }>`
   align-items: center;
   top: 15px;
   right: 15px;
-  font-size: 1.8em;
+  font-size: 1.5em;
+  width: 1.5em;
+  height: 1.5em;
   border-radius: 50%;
   background-color: ${(props) => props.bgcolor};
   color: white;

--- a/frontend/admin/src/portal/PromotionUploadModal/PromotionUploadModal.tsx
+++ b/frontend/admin/src/portal/PromotionUploadModal/PromotionUploadModal.tsx
@@ -124,7 +124,9 @@ const CloseButton = styled('button')<{ bgcolor: string }>`
   position: absolute;
   top: -0.5em;
   right: -0.5em;
-  font-size: 1.8em;
+  font-size: 1.5em;
+  width: 1.5em;
+  height: 1.5em;
   border-radius: 50%;
   background-color: ${(props) => props.bgcolor};
   color: white;

--- a/frontend/admin/src/theme/theme.ts
+++ b/frontend/admin/src/theme/theme.ts
@@ -21,4 +21,11 @@ export const theme = {
   ChartColorGreen: 'rgba(75, 192, 192, 0.6)',
   ChartColorPurple: 'rgba(153, 102, 255, 0.6)',
   ChartColorOrange: 'rgba(255, 159, 64, 0.6)',
+
+  GOLD: '#ffe34d',
+  BRONZE: '#cd7f32',
+  SILVER: 'rgba(192,192,192,0.6)',
+  LIGHTGRAY: 'rgba(211,211,211,0.7)',
+
+  WHITE: '#fff',
 };

--- a/frontend/admin/src/types/Category.ts
+++ b/frontend/admin/src/types/Category.ts
@@ -3,3 +3,8 @@ export interface Category {
   name: string;
   categories?: Category[];
 }
+
+export interface BestSelledCategory {
+  name: string;
+  total: number;
+}

--- a/frontend/admin/src/types/Category.ts
+++ b/frontend/admin/src/types/Category.ts
@@ -8,3 +8,8 @@ export interface BestSelledCategory {
   name: string;
   total: number;
 }
+
+export interface CategoryView {
+  name: string;
+  view: number;
+}

--- a/frontend/client/src/components/GoodsItem/GoodsItem.tsx
+++ b/frontend/client/src/components/GoodsItem/GoodsItem.tsx
@@ -83,12 +83,12 @@ const GoodsItem: React.FC<Props> = ({
         pushToast({ text: ERROR_WISH, color: theme.error });
       }
     },
-    [isWished]
+    [isWished, user]
   );
 
   useEffect(() => {
     setIsWished(isWish);
-  }, [isWish]);
+  }, [isWish, user]);
 
   return (
     <GoodsItemContainer onClick={handleClickGoodsItem}>

--- a/frontend/client/src/pages/GoodsDetail/GoodsDetailPage.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsDetailPage.tsx
@@ -75,8 +75,9 @@ const GoodsDetailPage = () => {
 };
 
 const GoodsDetailContainer = styled.div`
-  width: 1200px;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 1280px;
+  padding: 0 15% 0 15%;
   min-height: 70vh;
   margin-top: 5vh;
   animation: goodsDetailContainerShowEffect 0.5s 0s;

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsButtons/GoodsButtons.tsx
@@ -32,7 +32,7 @@ const GoodsButtons: React.FC<Props> = ({ isWish, clickable, onToggleWish, addToC
     <>
       <GoodsButtonsContainer>
         <WishButton onClick={() => handleClickButton(onToggleWish)}>
-          {isWish ? <FaHeart fill={theme.primary} /> : <FaRegHeart />}
+          {isWish && user.isLoggedIn ? <FaHeart fill={theme.primary} /> : <FaRegHeart />}
         </WishButton>
         <CartButton clickable={clickable} onClick={() => handleClickButton(addToCart)}>
           장바구니


### PR DESCRIPTION
## :bookmark_tabs: 제목

대시보드 - Bar chart, Top Selling Category (컴포넌트 API 개발) , 제품 조회수 Column 추가 및 적용

## 조회 수 연동하여 부모 Category의 view를 총합하여 보여줍니다.

https://user-images.githubusercontent.com/18898526/130542362-9a23323c-3d46-487c-8da9-b0cbef020183.mov


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역
FE
- [x] 카테고리 별 조회수를 볼 수 있는 Chart
- [x] Top Selling Category 컴포넌트

BE
- [x] 카테고리 별 조회수를 담은 목록 GET API 
- [x] Top Selling Category GET API
- [x] 제품 상세 fetching 될 때 조회수 Update 되도록 수정

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 자식 카테고리를 다 가져오면 너무 광범위해질 것 같아 부모 카테고리로 view의 총합을 가져와서 비교를 했습니다!