### PR TITLE
[HotFix] Webpack History Fallback 수정 및 admin 에서  사용할  Order API 추가

### DIFF
--- a/backend/src/controller/order.controller.ts
+++ b/backend/src/controller/order.controller.ts
@@ -5,7 +5,7 @@ import { GetAllOrderByUserIdProps } from '../types/Order';
 import { BadRequestError } from '../errors/client.error';
 import { INVALID_DATA } from '../constants/client.error.name';
 
-async function getOrdersPagination(req: Request, res: Response) {
+async function getOwnOrdersPagination(req: Request, res: Response) {
   const { page, limit } = req.query;
   if (page === undefined || limit === undefined) {
     throw new BadRequestError(INVALID_DATA);
@@ -15,7 +15,21 @@ async function getOrdersPagination(req: Request, res: Response) {
     page: Number(page),
     limit: Number(limit),
   };
-  const result = await OrderService.getOrdersPagination(OrderListQueryParams, userId);
+  const result = await OrderService.getOwnOrdersPagination(OrderListQueryParams, userId);
+  res.status(200).send({ result });
+}
+
+async function getAllOrdersPagination(req: Request, res: Response) {
+  const { page, limit } = req.query;
+  if (page === undefined || limit === undefined) {
+    throw new BadRequestError(INVALID_DATA);
+  }
+
+  const OrderListQueryParams: GetAllOrderByUserIdProps = {
+    page: Number(page),
+    limit: Number(limit),
+  };
+  const result = await OrderService.getAllOrdersPagination(OrderListQueryParams);
   res.status(200).send({ result });
 }
 
@@ -27,6 +41,7 @@ async function createOrder(req: CreateOrderRequest, res: Response) {
 }
 
 export const OrderController = {
-  getOrdersPagination,
+  getOwnOrdersPagination,
+  getAllOrdersPagination,
   createOrder,
 };

--- a/backend/src/repository/order.list.repository.ts
+++ b/backend/src/repository/order.list.repository.ts
@@ -51,6 +51,26 @@ async function getOwnOrdersPagination({ offset, limit }: PaginationProps, userId
   }
 }
 
+async function getAllOrderTotalCount(): Promise<number> {
+  return await getRepository(Order).count();
+}
+
+async function getAllOrdersPagination({ offset, limit }: PaginationProps): Promise<Order[]> {
+  try {
+    return await getRepository(Order).find({
+      relations: ['payment', 'orderItems', 'orderItems.goods', 'user'],
+      skip: offset,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(ORDER_LIST_DB_ERROR);
+  }
+}
+
 async function createOrder(userId: number, body: CreateOrder): Promise<Order> {
   try {
     const { orderMemo, receiver, zipCode, address, subAddress, paymentId } = body;
@@ -77,5 +97,7 @@ export const OrderListRepository = {
   getOrders,
   getOwnOrderTotalCount,
   getOwnOrdersPagination,
+  getAllOrderTotalCount,
+  getAllOrdersPagination,
   createOrder,
 };

--- a/backend/src/router/order.router.ts
+++ b/backend/src/router/order.router.ts
@@ -5,7 +5,10 @@ import isAuthenticate from '../middlewares/is.authenticate';
 
 const router = express.Router();
 
-router.get('/', isAuthenticate, wrapAsync(OrderController.getOrdersPagination));
+router.get('/', isAuthenticate, wrapAsync(OrderController.getOwnOrdersPagination));
 router.post('/', isAuthenticate, wrapAsync(OrderController.createOrder));
+
+// 관리자 전용 API. TODO: 추후 관리자 권한 미들웨어 추가하기
+router.get('/admin', wrapAsync(OrderController.getAllOrdersPagination));
 
 export default router;

--- a/backend/src/service/order.service.ts
+++ b/backend/src/service/order.service.ts
@@ -13,7 +13,7 @@ import { getTotalPage, pagination } from '../utils/pagination';
 import { PaginationProps } from '../types/Pagination';
 import { PaymentRepository } from '../repository/payment.repository';
 
-async function getOrdersPagination(
+async function getOwnOrdersPagination(
   { page, limit }: GetAllOrderByUserIdProps,
   userId: number
 ): Promise<OrderListPaginationResponse> {
@@ -27,6 +27,29 @@ async function getOrdersPagination(
   };
 
   const orders = await OrderListRepository.getOwnOrdersPagination(option, userId);
+
+  return {
+    meta: {
+      page: newPage,
+      limit,
+      totalPage: getTotalPage(totalCount, limit),
+      totalCount,
+    },
+    orderList: orders,
+  };
+}
+
+async function getAllOrdersPagination({ page, limit }: GetAllOrderByUserIdProps): Promise<OrderListPaginationResponse> {
+  const totalCount = await OrderListRepository.getAllOrderTotalCount();
+
+  const newPage = Math.min(getTotalPage(totalCount, limit), page);
+
+  const option: PaginationProps = {
+    offset: pagination.calculateOffset(newPage, limit),
+    limit,
+  };
+
+  const orders = await OrderListRepository.getAllOrdersPagination(option);
 
   return {
     meta: {
@@ -77,6 +100,7 @@ async function validateCreateOrder(body: CreateOrderBody): Promise<boolean> {
 }
 
 export const OrderService = {
-  getOrdersPagination,
+  getAllOrdersPagination,
+  getOwnOrdersPagination,
   createOrder,
 };

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "webpack serve --config webpack.dev.js --progress",
     "build": "webpack --config webpack.prod.js",
+    "build:dev": "webpack --config webpack.dev.js",
     "prestart": "npm build",
     "start": "npm run dev",
     "test": "jest",
@@ -56,7 +57,7 @@
     "typescript": "4.3.5",
     "url-loader": "4.1.1",
     "webpack": "5.44.0",
-    "webpack-cli": "4.7.2",
+    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.8.0"
   }

--- a/frontend/admin/src/apis/orderAPI.ts
+++ b/frontend/admin/src/apis/orderAPI.ts
@@ -3,16 +3,16 @@ import { OrderPaginationResult } from '@src/types/Order';
 
 const DEFAULT_ORDER_LIMIT = 5;
 
-export interface GetOrdersProps {
+export interface GetAllOrdersProps {
   page: number;
   limit?: number;
 }
 
-export const getOrders = async ({
+export const getAllOrders = async ({
   page,
   limit = DEFAULT_ORDER_LIMIT,
-}: GetOrdersProps): Promise<APIResponse<OrderPaginationResult>> => {
-  const res = await checkedFetch(`/api/order?page=${page}&limit=${limit}`, {
+}: GetAllOrdersProps): Promise<APIResponse<OrderPaginationResult>> => {
+  const res = await checkedFetch(`/api/order/admin?page=${page}&limit=${limit}`, {
     method: 'GET',
     credentials: 'include',
     headers: {

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -1,4 +1,4 @@
-import { getOrders } from '@src/apis/orderAPI';
+import { getAllOrders } from '@src/apis/orderAPI';
 import useInterval from '@src/hooks/useInterval';
 import { styled } from '@src/lib/CustomStyledComponent';
 import LiveOrderCard from '@src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard';
@@ -17,10 +17,14 @@ const LiveOrderList = () => {
 
   const updateOrders = useCallback(async () => {
     setUpdateTime(new Date());
-    const {
-      result: { orderList },
-    } = await getOrders({ page: DEFAULT_START_PAGE, limit: DEFAULT_LIVE_ORDER_LIMIT });
-    setOrder(orderList);
+    try {
+      const {
+        result: { orderList },
+      } = await getAllOrders({ page: DEFAULT_START_PAGE, limit: DEFAULT_LIVE_ORDER_LIMIT });
+      setOrder(orderList);
+    } catch (err) {
+      console.error(err);
+    }
   }, [setOrder, setUpdateTime]);
 
   useEffect(() => {

--- a/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
@@ -1,4 +1,4 @@
-import { getOrders } from '@src/apis/orderAPI';
+import { getAllOrders } from '@src/apis/orderAPI';
 import Loading from '@src/components/Loading/Loading';
 import Paginator from '@src/components/Paginator/Paginator';
 import OrderTable from '@src/pages/OrderAdmin/OrderTable/OrderTable';
@@ -16,7 +16,7 @@ const OrderAdmin = () => {
 
   const fetchOrders = async () => {
     try {
-      const { result } = await getOrders({
+      const { result } = await getAllOrders({
         page: currentPage,
         limit: DEFAULT_LIMIT_ORDER,
       });

--- a/frontend/admin/webpack.common.js
+++ b/frontend/admin/webpack.common.js
@@ -63,7 +63,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'admin_bundle.js',
-    publicPath: '/dist',
+    publicPath: '/',
   },
 
   plugins: [

--- a/frontend/admin/webpack.dev.js
+++ b/frontend/admin/webpack.dev.js
@@ -9,9 +9,7 @@ module.exports = merge(common, {
     overlay: true,
     port: 8082,
     stats: 'errors-only',
-    historyApiFallback: {
-      index: '/dist/admin_index.html',
-    },
+    historyApiFallback: true,
     proxy: {
       '/api': 'http://localhost:8080',
     },

--- a/frontend/client/src/apis/orderAPI.ts
+++ b/frontend/client/src/apis/orderAPI.ts
@@ -42,9 +42,6 @@ export const getOrders = async ({
   const res = await checkedFetch(`/api/order?page=${page}&limit=${limit}`, {
     method: 'GET',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
   });
   return await res.json();
 };


### PR DESCRIPTION
## :bookmark_tabs: 제목

긴급으로 수정내용 반영하고자합니다. 

- 관리자 페이지에서 사용할 Order API 추가 (관리자페이지에서 권한이 적용되는 API를 사용하지않고 새로운 API 생성)

- 번들링 후 배포시 발생하는 버그 제거.  (webpack publicPath를 잘못 지정해서 발생)

