### PR TITLE
[feature/186] 최근 상품 조회하는 사이드바 UI 수정 및 각종 사소한 Client UI/UX 수정 

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -21,6 +21,7 @@ import { PromotionRepository } from './repository/promotion.repository';
 import { PaymentRepository } from './repository/payment.repository';
 import { OrderListRepository } from './repository/order.list.repository';
 import { OrderItemRepository } from './repository/order.item.repository';
+import { GoodsRepository } from './repository/goods.repository';
 
 export default async function () {
   await createConnection({
@@ -63,13 +64,21 @@ async function createDefaultUser(name: string) {
 
 async function createDefaultCategory() {
   const categories = [
-    { name: 'A' },
-    { parent: 'A', name: 'A1' },
-    { parent: 'A', name: 'A2' },
-    { parent: 'A', name: 'A3' },
-    { name: 'B' },
-    { parent: 'B', name: 'B1' },
-    { parent: 'B', name: 'B2' },
+    { name: '완전 랜덤 카테고리' },
+    { parent: '완전 랜덤 카테고리', name: 'A1' },
+    { parent: '완전 랜덤 카테고리', name: 'A2' },
+    { parent: '완전 랜덤 카테고리', name: 'A3' },
+    { name: '그냥 랜덤 카테고리' },
+    { parent: '그냥 랜덤 카테고리', name: 'B1' },
+    { parent: '그냥 랜덤 카테고리', name: 'B2' },
+    { name: 'ㅋㅋ 모음' },
+    { parent: 'ㅋㅋ 모음', name: '영화' },
+    { parent: 'ㅋㅋ 모음', name: '영화' },
+    { parent: 'ㅋㅋ 모음', name: '장난감' },
+    { name: '평가' },
+    { parent: '평가', name: '엄격' },
+    { parent: '평가', name: '장점' },
+    { parent: '평가', name: '쾌활' },
   ];
   for (const category of categories) {
     await createCategory(category.name, category.parent);
@@ -215,13 +224,16 @@ async function createDefaultPromotions() {
     'https://user-images.githubusercontent.com/20085849/128992450-eb086cff-3b2a-4d4a-8b01-e3a8a8eaa754.gif',
   ];
   const promotion = await PromotionRepository.getPromotions();
-  let goodsId = 1;
+  const randomGoods = await getRepository(Goods).findOne();
+  if (!randomGoods) {
+    console.log('상품이 없어서 프로모션을 추가 못했습니다.');
+    return;
+  }
   for (const img of examplePromotionImgs) {
     const exist = promotion.find((p) => p.imgUrl === img);
     if (!exist) {
-      const newPromotion = await PromotionRepository.createPromotion(goodsId, img);
-      console.log('프로모션 생성 : id' + goodsId + 'url :' + newPromotion.imgUrl);
-      goodsId++;
+      const newPromotion = await PromotionRepository.createPromotion(randomGoods.id, img);
+      console.log('프로모션 생성 : id' + randomGoods.id + 'url :' + newPromotion.imgUrl);
     }
   }
 }

--- a/backend/src/entity/DeliveryInfo.ts
+++ b/backend/src/entity/DeliveryInfo.ts
@@ -5,13 +5,13 @@ export class DeliveryInfo {
   @PrimaryGeneratedColumn({ type: 'int', unsigned: true })
   id: number;
 
-  @Column({ type: 'varchar', length: 10 })
+  @Column({ type: 'varchar', length: 255 })
   name: string;
 
   @Column({ type: 'int' })
   deliveryFee: number;
 
-  @Column({ type: 'varchar', length: 20 })
+  @Column({ type: 'varchar', length: 255 })
   deliveryDetail: string;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/backend/src/entity/Order.ts
+++ b/backend/src/entity/Order.ts
@@ -19,19 +19,16 @@ export class Order {
   @Column({ type: 'varchar', length: 5 })
   state: string;
 
-  @Column({ type: 'varchar', length: 200 })
-  orderMemo: string;
-
   @Column({ type: 'varchar', length: 20 })
   receiver: string;
 
   @Column({ type: 'varchar', length: 7 })
   zipCode: string;
 
-  @Column({ type: 'varchar', length: 50 })
+  @Column({ type: 'varchar', length: 255 })
   address: string;
 
-  @Column({ type: 'varchar', length: 50 })
+  @Column({ type: 'varchar', length: 255 })
   subAddress: string;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@src/lib/CustomStyledComponent';
 import { GetGoodsByOptionProps, GoodsItem, GoodsPaginationResult } from '@src/types/Goods';
 import GoodsTableHead from '@src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead';

--- a/frontend/admin/webpack.dev.js
+++ b/frontend/admin/webpack.dev.js
@@ -5,11 +5,15 @@ const common = require('./webpack.common.js');
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+
   devServer: {
+    publicPath: '/',
     overlay: true,
     port: 8082,
     stats: 'errors-only',
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/dist/admin_index.html',
+    },
     proxy: {
       '/api': 'http://localhost:8080',
     },

--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -49,7 +49,6 @@ export default function App() {
           <Footer />
         </FooterContainer>
       </Router>
-
       <GlobalStyles />
     </>
   );
@@ -62,11 +61,15 @@ interface FooterContainerProps {
 }
 
 const FooterContainer = styled.div<FooterContainerProps>`
-  width: 100%;
+  min-width: 1280px;
+  @media (max-width: 1280px) {
+    width: 100%;
+  }
+  height: 20vh;
   background-color: ${(props) => props.theme.dustWhite};
 `;
 
 const ContentContainer = styled.div`
   width: 100%;
-  min-height: 60vh;
+  min-height: 70vh;
 `;

--- a/frontend/client/src/components/Header/Header.tsx
+++ b/frontend/client/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import useUserState from '@src/hooks/useUserState';
+import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import HeaderBottom from './HeaderBottom/HeaderBottom';
@@ -8,9 +9,14 @@ const Header = () => {
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [userRecoil, userRecoilDispatch] = useUserState();
   const [isScrolled, setIsScrolled] = useState(false);
+  const pushToast = usePushToast();
 
   const handleLogout = useCallback(async () => {
-    await userRecoilDispatch({ type: 'LOGOUT' });
+    try {
+      await userRecoilDispatch({ type: 'LOGOUT' });
+    } catch (err) {
+      pushToast({ text: '로그아웃 도중 서버 오류가 발생했습니다.' });
+    }
   }, [userRecoilDispatch]);
 
   useEffect(() => {
@@ -25,10 +31,15 @@ const Header = () => {
     observer.observe(sentinelRef.current as HTMLElement);
   }, []);
 
-  useEffect(() => {
-    async function checkLoggedIn() {
+  async function checkLoggedIn() {
+    try {
       await userRecoilDispatch({ type: 'CHECK' });
+    } catch (err) {
+      pushToast({ text: '로그인 도중 서버 오류가 발생했습니다.' });
     }
+  }
+
+  useEffect(() => {
     checkLoggedIn();
   }, []);
 

--- a/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/IconContainerStyle.ts
+++ b/frontend/client/src/components/Header/HeaderBottom/HeaderIconContainer/IconContainerStyle.ts
@@ -19,14 +19,16 @@ export const IconTitle = styled.span`
 `;
 
 export const IconNumber = styled.span`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
-  top: 0;
-  right: 0.75rem;
+  top: -0.5rem;
+  right: 0.5rem;
   color: white;
   background-color: ${(prop) => prop.theme.primary};
-  width: 0.75rem;
-  height: 0.75rem;
-  text-align: center;
-  font-size: 0.75rem;
+  width: 1rem;
+  height: 1rem;
+  font-size: 0.8rem;
   border-radius: 100%;
 `;

--- a/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
+++ b/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
@@ -46,9 +46,9 @@ const PromotionCarouselContainer = styled.div`
     slick 슬라이더의 마지막 슬라이드가 상단에 위치하여 마지막 슬라이드만 onClick이 발생하는 문제가 있었습니다!
     하여 활성화된 슬라이더의 z-index를 1로 설정하였습니다.
   */
-  /* .slick-active {
+  .slick-active {
     z-index: 1;
-  } */
+  }
 `;
 
 const PromotionImage = styled.img`

--- a/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
+++ b/frontend/client/src/components/PromotionCarousel/PromotionCarousel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import Slider from 'react-slick';
+import Slider, { Settings } from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import { Promotion } from '@src/types/Promotion';
@@ -11,7 +11,7 @@ interface Props {
   promotions: Promotion[];
 }
 
-const SLIDE_SETTING = {
+const SLIDE_SETTING: Settings = {
   dots: true,
   infinite: true,
   speed: 500,
@@ -22,7 +22,6 @@ const SLIDE_SETTING = {
   autoplaySpeed: 3000,
 };
 
-// TODO:(jiho) Promotion 타입에 fetchURL이 있어야하지않을가? 항상 상품 상세화면으로 가야하나? 아니면 다른 화면으로 갈 수 있지않을까?
 const PromotionCarousel: React.FC<Props> = ({ promotions }) => {
   const push = usePushHistory();
   const handleClickGoodsItem = (promotionId: number) => {
@@ -43,18 +42,17 @@ const PromotionCarousel: React.FC<Props> = ({ promotions }) => {
 
 const PromotionCarouselContainer = styled.div`
   width: 100%;
-  overflow: hidden;
   /* 
     slick 슬라이더의 마지막 슬라이드가 상단에 위치하여 마지막 슬라이드만 onClick이 발생하는 문제가 있었습니다!
     하여 활성화된 슬라이더의 z-index를 1로 설정하였습니다.
   */
-  .slick-active {
+  /* .slick-active {
     z-index: 1;
-  }
+  } */
 `;
 
 const PromotionImage = styled.img`
-  width: 100%;
+  height: 100%;
   user-select: none;
   object-fit: contain;
   outline: none;

--- a/frontend/client/src/components/SideBar/RecentGoodsView.tsx
+++ b/frontend/client/src/components/SideBar/RecentGoodsView.tsx
@@ -10,7 +10,7 @@ interface SideBarProps {
   onClickGoods?: (goodsId: number) => void;
 }
 
-export const COUNT_OF_SHOWN_GOODS = 3;
+export const COUNT_OF_SHOWN_GOODS = 4;
 
 const RecentGoodsView: React.FC<SideBarProps> = ({ goodsList = [], onDeleteGoods, onClickGoods }) => {
   const [recentGoodsIdx, setRecentGoodsIndx] = useState(0);
@@ -77,19 +77,21 @@ interface SideBarContainerProps {
 }
 
 const RecentGoodsViewContainer = styled.div<SideBarContainerProps>`
+  flex-grow: 1;
+  padding: 5px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 `;
 
 const RecentGoodsList = styled.ul`
-  flex-grow: 1;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
   overflow-y: scroll;
-  min-height: 300px;
+
+  min-height: 400px;
   padding: 5px 0px;
 `;
 

--- a/frontend/client/src/components/SideBar/SideBar.tsx
+++ b/frontend/client/src/components/SideBar/SideBar.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import RecentGoodsView from '@src/components/SideBar/RecentGoodsView';
 import useRecentGoodsHistory from '@src/hooks/useRecentGoodsHistory';
 import { usePushHistory } from '@src/lib/CustomRouter';
 
 const SideBar = () => {
+  const [isShow, setIsShow] = useState<boolean>(false);
   const [recentGoodsList, setRecentGoodsList] = useRecentGoodsHistory();
   const pushHistory = usePushHistory();
 
@@ -17,8 +18,13 @@ const SideBar = () => {
     pushHistory(`/detail/${id}`);
   };
 
+  const toggleDisplay = () => {
+    setIsShow(!isShow);
+  };
+
   return (
-    <SideBarContainer>
+    <SideBarContainer hide={!isShow}>
+      <ToggleButton onClick={() => toggleDisplay()}>{isShow ? '숨기기' : '최근 본 상품 보기'}</ToggleButton>
       <RecentGoodsView
         goodsList={recentGoodsList}
         onDeleteGoods={handleDeleteRecentGoods}
@@ -28,18 +34,40 @@ const SideBar = () => {
   );
 };
 
-const SideBarContainer = styled.div`
+interface SideBarContainerProps {
+  hide: boolean;
+}
+
+const SideBarContainer = styled.div<SideBarContainerProps>`
+  display: flex;
+  align-items: center;
   z-index: 99;
   position: fixed;
+
   right: 0px;
   top: 50%;
-  transform: translate(0, -50%);
-  width: 140px;
-  padding: 0px 10px;
+  ${(props) => (props.hide ? 'transform: translate(80%, -50%);' : 'transform: translate(0%, -50%);')}
+  will-change: transform;
+  transition: transform 0.2s;
+  width: 160px;
   border-width: 1px;
   border-style: solid;
   border-color: ${(props) => props.theme.line};
   background-color: white;
+`;
+
+const ToggleButton = styled.div`
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 20%;
+  padding: 10px;
+  font-size: 1rem;
+  font-weight: 600;
+  writing-mode: vertical-lr;
 `;
 
 export default SideBar;

--- a/frontend/client/src/pages/Cart/CartPage.tsx
+++ b/frontend/client/src/pages/Cart/CartPage.tsx
@@ -1,9 +1,7 @@
 import { deleteCarts, getCarts, updateCart } from '@src/apis/cartAPI';
 import PageHeader from '@src/components/PageHeader/PageHeader';
 import usePushToOrderPage from '@src/hooks/usePushToOrderPage';
-import { usePushHistory } from '@src/lib/CustomRouter';
 import { cartState } from '@src/recoil/cartState';
-import { CartGoods } from '@src/types/Goods';
 import composeComponent from '@src/utils/composeComponent';
 import withLoggedIn from '@src/utils/withLoggedIn';
 import withScrollToTopOnMount from '@src/utils/withScrollToTopOnMount';
@@ -52,8 +50,11 @@ const CartPage: React.FC = () => {
   const handleChangeIsSelected = useCallback(
     (id: number, isSelected: boolean) => {
       const changedCartGoodsList = cartGoodsList.map((cartGoods) => {
-        if (cartGoods.id === id) return { ...cartGoods, isSelected };
-        return cartGoods;
+        if (cartGoods.id === id) {
+          return { ...cartGoods, isSelected };
+        } else {
+          return cartGoods;
+        }
       });
       setCartGoodsList(changedCartGoodsList);
     },

--- a/frontend/client/src/pages/GoodsDetail/GoodsInfo/GoodsInfo.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInfo/GoodsInfo.tsx
@@ -22,6 +22,7 @@ const GoodsInfo: React.FC<GoodsInfoProps> = ({
         {discountRate > 0 && (
           <InfoContent labelText={'정가'}>
             <Price>{getPriceText(price)}원</Price>
+            <DiscountRate>{discountRate} %</DiscountRate>
           </InfoContent>
         )}
         <InfoContent labelText={'판매가격'}>
@@ -54,6 +55,14 @@ const GoodsContent = styled.div`
 const Price = styled.p`
   text-decoration: line-through;
 `;
+
+const DiscountRate = styled.p`
+  font-size: 1.2rem;
+  margin-left: 0.5rem;
+  font-weight: 600;
+  color: red;
+`;
+
 const SalePrice = styled.p`
   font-weight: 600;
   font-family: 'Montserrat', sans-serif;

--- a/frontend/client/src/pages/GoodsDetail/GoodsInfo/InfoContent/InfoContent.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInfo/InfoContent/InfoContent.tsx
@@ -9,7 +9,7 @@ const InfoContent: React.FC<Props> = ({ labelText, children }) => {
   return (
     <InfoContentContainer>
       <span>{labelText}</span>
-      <div>{children}</div>
+      <InfoChild>{children}</InfoChild>
     </InfoContentContainer>
   );
 };
@@ -25,6 +25,10 @@ const InfoContentContainer = styled.div`
     width: 5rem;
     font-weight: 600;
   }
+`;
+
+const InfoChild = styled.div`
+  display: flex;
 `;
 
 export default InfoContent;

--- a/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
+++ b/frontend/client/src/pages/GoodsDetail/GoodsInteractive/GoodsInteractive.tsx
@@ -14,6 +14,8 @@ interface Props {
   goods: DetailGoods;
 }
 
+const DEFAULT_AMOUNT = 1;
+
 const ERROR_SERVER = '서버 문제로 요청에 실패하였습니다!';
 const ADD_WISH = '찜하기 목록에 추가하였습니다.';
 const DELETE_WISH = '찜하기 목록에서 삭제하였습니다.';
@@ -27,7 +29,7 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
 
   const [isWished, setIsWished] = useState(isWish);
   const [isOver, setIsOver] = useState(false);
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState(DEFAULT_AMOUNT);
   const [disabled, setDisabled] = useState(false);
 
   const handleToWish = useCallback(async () => {
@@ -86,7 +88,7 @@ const GoodsInteractive: React.FC<Props> = ({ goods }) => {
 
   useEffect(() => {
     setIsWished(isWish);
-    setAmount(0);
+    setAmount(DEFAULT_AMOUNT);
   }, [id]);
 
   return (

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -48,8 +48,12 @@ const Main = () => {
 
 const PromotionContainer = styled.div`
   max-height: 300px;
-  width: 100%;
+  min-width: 1280px;
+
   overflow: hidden;
+  @media (max-width: 1280px) {
+    width: 100%;
+  }
 `;
 
 const MainContentContainer = styled.div`

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -48,20 +48,8 @@ const Main = () => {
 
 const PromotionContainer = styled.div`
   max-height: 300px;
-  min-width: 1500px;
+  width: 100%;
   overflow: hidden;
-  animation: pageShowEffect 0.5s 0s;
-
-  @keyframes pageShowEffect {
-    from {
-      opacity: 0;
-      transform: translate(-100%, 0%);
-    }
-    to {
-      opacity: 1;
-      transform: translate(0%, 0%);
-    }
-  }
 `;
 
 const MainContentContainer = styled.div`

--- a/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
+++ b/frontend/client/src/pages/MyPage/MyAddressView/MyAddressView.tsx
@@ -11,14 +11,8 @@ import { usePushToast } from '@src/lib/ToastProvider/ToastProvider';
 
 const MyAddressView = () => {
   const [addresses, setAddresses] = useState<AddressInfo[]>([]);
-  const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
   const [isOpenManageModal, setIsOpenManageModal] = useState(false);
   const pushToast = usePushToast();
-
-  const toggleCreateModal = () => {
-    setIsOpenCreateModal(!isOpenCreateModal);
-    fetchAddresses();
-  };
 
   const toggleManageModal = () => {
     setIsOpenManageModal(!isOpenManageModal);
@@ -47,11 +41,9 @@ const MyAddressView = () => {
       <Topic>배송지 정보</Topic>
 
       <AddressControlButtonContainer>
-        <PrimaryButton onClick={toggleCreateModal}>배송지 추가하기</PrimaryButton>
         <PrimaryButton onClick={toggleManageModal}>배송지 수정하기</PrimaryButton>
       </AddressControlButtonContainer>
 
-      {isOpenCreateModal && <AddressCreateModal onClose={toggleCreateModal} />}
       {isOpenManageModal && <AddressManageModal onClose={toggleManageModal} />}
 
       <AddressInfoListItem isPrimary>


### PR DESCRIPTION
## :bookmark_tabs: 제목

최근 상품 조회 UI개선을 위한 작업을 진행했습니다.

그리고 Client App에서 수정할 만한 사소한 작업들을 진행했습니다.

- 이전 사이드드바 이미지

<img width="303" alt="스크린샷 2021-08-24 오후 5 50 18" src="https://user-images.githubusercontent.com/20085849/130587210-659d860d-5e80-458b-9095-b8852646c22b.png">

- 수정 후 사이드바 이미지

![Aug-24-2021 17-51-06](https://user-images.githubusercontent.com/20085849/130587403-597677a6-707d-4bbb-a995-d3e8f7a41327.gif)


## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 최근 상품 조회 토글을 통해 확장가능하도록 수정
- [x] 상품 상세화면에서 세일 정보 노출
- [x] 프로모션과 푸터 컨테이너에 미디어 쿼리 적용

