### PR TITLE
[feature/191] 리뷰 컨테이너 목업 생성

### DIFF
--- a/frontend/client/src/components/Avatar/Avatar.tsx
+++ b/frontend/client/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+import EmptyAvatarImg from '@src/assets/empty-kim.gif';
+
+interface AvatarProps {
+  imgUrl?: string | null;
+}
+
+const Avatar: React.FC<AvatarProps> = ({ imgUrl }) => {
+  return <Image src={imgUrl ?? EmptyAvatarImg} />;
+};
+
+const Image = styled.img`
+  object-fit: cover;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+`;
+
+export default Avatar;

--- a/frontend/client/src/components/AwesomeButton/AwesomeButton.tsx
+++ b/frontend/client/src/components/AwesomeButton/AwesomeButton.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const AwesomeButton = styled.button`
+  cursor: pointer;
+  border: 0.25rem dashed ${(props) => props.theme.line};
+  padding: 0.5rem 1rem;
+  background-color: white;
+  transition: 0.2s;
+  font-family: inherit;
+  font-size: 1rem;
+
+  :hover {
+    border: 0.25rem solid black;
+  }
+
+  :disabled {
+    cursor: initial;
+    color: ${(props) => props.theme.placeholder};
+    background-color: ${(props) => props.theme.dustWhite};
+    border: 0.25rem dashed ${(props) => props.theme.line};
+  }
+`;
+
+export default AwesomeButton;

--- a/frontend/client/src/components/Rate/Rate.tsx
+++ b/frontend/client/src/components/Rate/Rate.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import Star from '../Star/Star';
+
+interface RateProps {
+  rate: number;
+}
+
+const MAX_RATE = 5;
+
+const Rate: React.FC<RateProps> = ({ rate }) => {
+  return (
+    <Layout>
+      {/* 이 사례에선 key에 index를 부여하는 것이 적절합니다. */}
+      {Array.from({ length: MAX_RATE }).map((_, index) => (
+        <Star key={index} isFilled={rate > index} />
+      ))}
+    </Layout>
+  );
+};
+
+const Layout = styled.div`
+  display: flex;
+  gap: 0.25rem;
+`;
+
+export default Rate;

--- a/frontend/client/src/components/ReviewCard/ReviewCard.tsx
+++ b/frontend/client/src/components/ReviewCard/ReviewCard.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import Avatar from '../Avatar/Avatar';
 import Rate from '../Rate/Rate';
 import TempImg from '@src/assets/empty-img.png';
+import AwesomeButton from '../AwesomeButton/AwesomeButton';
 
 interface Props {}
 
@@ -24,8 +25,8 @@ const ReviewCard: React.FC<Props> = ({}) => {
         </TopLeftBox>
         {/* 자기 것이면 렌더링한다! */}
         <TopRightBox>
-          <Button>수정</Button>
-          <Button disabled>삭제</Button>
+          <AwesomeButton>수정</AwesomeButton>
+          <AwesomeButton disabled>삭제</AwesomeButton>
         </TopRightBox>
       </TopBox>
       <GoodsInfoText>상품 정보</GoodsInfoText>
@@ -44,27 +45,6 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-`;
-
-const Button = styled.button`
-  cursor: pointer;
-  border: 0.25rem dashed ${(props) => props.theme.line};
-  padding: 0.5rem 1rem;
-  background-color: white;
-  transition: 0.2s;
-  font-family: inherit;
-  font-size: 1rem;
-
-  :hover {
-    border: 0.25rem solid black;
-  }
-
-  :disabled {
-    cursor: initial;
-    color: ${(props) => props.theme.placeholder};
-    background-color: ${(props) => props.theme.dustWhite};
-    border: 0.25rem dashed ${(props) => props.theme.line};
-  }
 `;
 
 const TopBox = styled.div`

--- a/frontend/client/src/components/ReviewCard/ReviewCard.tsx
+++ b/frontend/client/src/components/ReviewCard/ReviewCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Avatar from '../Avatar/Avatar';
 import Rate from '../Rate/Rate';
-import TempImg from '@src/assets/empty-kim.gif';
+import TempImg from '@src/assets/empty-img.png';
 
 interface Props {}
 
@@ -22,9 +22,10 @@ const ReviewCard: React.FC<Props> = ({}) => {
             </RateAndDateBox>
           </NameAndRateBox>
         </TopLeftBox>
+        {/* 자기 것이면 렌더링한다! */}
         <TopRightBox>
-          <button>수정</button>
-          <button>삭제</button>
+          <Button>수정</Button>
+          <Button disabled>삭제</Button>
         </TopRightBox>
       </TopBox>
       <GoodsInfoText>상품 정보</GoodsInfoText>
@@ -43,6 +44,27 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+`;
+
+const Button = styled.button`
+  cursor: pointer;
+  border: 0.25rem dashed ${(props) => props.theme.line};
+  padding: 0.5rem 1rem;
+  background-color: white;
+  transition: 0.2s;
+  font-family: inherit;
+  font-size: 1rem;
+
+  :hover {
+    border: 0.25rem solid black;
+  }
+
+  :disabled {
+    cursor: initial;
+    color: ${(props) => props.theme.placeholder};
+    background-color: ${(props) => props.theme.dustWhite};
+    border: 0.25rem dashed ${(props) => props.theme.line};
+  }
 `;
 
 const TopBox = styled.div`

--- a/frontend/client/src/components/ReviewCard/ReviewCard.tsx
+++ b/frontend/client/src/components/ReviewCard/ReviewCard.tsx
@@ -59,7 +59,7 @@ const NameAndRateBox = styled.div`
 
 const RateAndDateBox = styled.div`
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
   align-items: center;
 `;
 

--- a/frontend/client/src/components/ReviewCard/ReviewCard.tsx
+++ b/frontend/client/src/components/ReviewCard/ReviewCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Avatar from '../Avatar/Avatar';
 import Rate from '../Rate/Rate';
+import TempImg from '@src/assets/empty-kim.gif';
 
 interface Props {}
 
@@ -14,10 +15,10 @@ const ReviewCard: React.FC<Props> = ({}) => {
         <TopLeftBox>
           <Avatar />
           <NameAndRateBox>
-            <div>사용자명</div>
+            <NameText>사용자명</NameText>
             <RateAndDateBox>
               <Rate rate={3} />
-              <div>2020.12.12.</div>
+              <DateText>2020.12.12.</DateText>
             </RateAndDateBox>
           </NameAndRateBox>
         </TopLeftBox>
@@ -26,8 +27,13 @@ const ReviewCard: React.FC<Props> = ({}) => {
           <button>삭제</button>
         </TopRightBox>
       </TopBox>
-      <div>상품 정보</div>
-      <div>이미지 리스트</div>
+      <GoodsInfoText>상품 정보</GoodsInfoText>
+      {/* 이미지가 있다면 렌더링한다! */}
+      <IamgesWrapper>
+        <Image src={TempImg} />
+        <Image src={TempImg} />
+        <Image src={TempImg} />
+      </IamgesWrapper>
       <ReviewContents>리뷰 내용</ReviewContents>
     </Wrapper>
   );
@@ -57,15 +63,39 @@ const NameAndRateBox = styled.div`
   gap: 0.25rem;
 `;
 
+const NameText = styled.div`
+  font-size: 1rem;
+`;
+
 const RateAndDateBox = styled.div`
   display: flex;
   gap: 0.5rem;
   align-items: center;
 `;
 
+const DateText = styled.div`
+  font-size: 0.75rem;
+  color: ${(props) => props.theme.label};
+`;
+
 const TopRightBox = styled.div`
   display: flex;
   gap: 0.25rem;
+`;
+
+const GoodsInfoText = styled.div`
+  color: ${(props) => props.theme.label};
+`;
+
+const IamgesWrapper = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const Image = styled.img`
+  object-fit: cover;
+  width: 4rem;
+  height: 4rem;
 `;
 
 const ReviewContents = styled.div`

--- a/frontend/client/src/components/ReviewCard/ReviewCard.tsx
+++ b/frontend/client/src/components/ReviewCard/ReviewCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import styled from 'styled-components';
+import Avatar from '../Avatar/Avatar';
+import Rate from '../Rate/Rate';
+
+interface Props {}
+
+const ReviewCard: React.FC<Props> = ({}) => {
+  // props: id, userName, rate, createAt, 상품 정보, 이미지 리스트, 리뷰 내용
+
+  return (
+    <Wrapper>
+      <TopBox>
+        <TopLeftBox>
+          <Avatar />
+          <NameAndRateBox>
+            <div>사용자명</div>
+            <RateAndDateBox>
+              <Rate rate={3} />
+              <div>2020.12.12.</div>
+            </RateAndDateBox>
+          </NameAndRateBox>
+        </TopLeftBox>
+        <TopRightBox>
+          <button>수정</button>
+          <button>삭제</button>
+        </TopRightBox>
+      </TopBox>
+      <div>상품 정보</div>
+      <div>이미지 리스트</div>
+      <ReviewContents>리뷰 내용</ReviewContents>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const TopBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TopLeftBox = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+const NameAndRateBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+const RateAndDateBox = styled.div`
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+`;
+
+const TopRightBox = styled.div`
+  display: flex;
+  gap: 0.25rem;
+`;
+
+const ReviewContents = styled.div`
+  /* 개행문자를 인식하고 적용하는 css 프로퍼티입니다. */
+  white-space: pre-wrap;
+`;
+
+export default ReviewCard;

--- a/frontend/client/src/components/ReviewContainer/ReviewContainer.tsx
+++ b/frontend/client/src/components/ReviewContainer/ReviewContainer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Paginator from '../Paginator/Paginator';
+import ReviewContainerHeader from '../ReviewContainerHeader/ReviewContainerHeader';
+import ReviewList from '../ReviewList/ReviewList';
+
+interface Props {}
+
+// TODO: NoData, Loading
+const ReviewContainer: React.FC<Props> = ({}) => {
+  return (
+    <>
+      <ReviewContainerHeader />
+      <ReviewList />
+      <Paginator totalPage={3} currentPage={1} setPage={() => {}} />
+    </>
+  );
+};
+
+export default ReviewContainer;

--- a/frontend/client/src/components/ReviewContainer/ReviewContainer.tsx
+++ b/frontend/client/src/components/ReviewContainer/ReviewContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import Paginator from '../Paginator/Paginator';
 import ReviewContainerHeader from '../ReviewContainerHeader/ReviewContainerHeader';
 import ReviewList from '../ReviewList/ReviewList';
@@ -8,12 +9,14 @@ interface Props {}
 // TODO: NoData, Loading
 const ReviewContainer: React.FC<Props> = ({}) => {
   return (
-    <>
+    <Wrapper>
       <ReviewContainerHeader />
       <ReviewList />
       <Paginator totalPage={3} currentPage={1} setPage={() => {}} />
-    </>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div``;
 
 export default ReviewContainer;

--- a/frontend/client/src/components/ReviewContainerHeader/ReviewContainerHeader.tsx
+++ b/frontend/client/src/components/ReviewContainerHeader/ReviewContainerHeader.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { FaPencilAlt } from 'react-icons/fa';
+import AwesomeButton from '../AwesomeButton/AwesomeButton';
 
 interface Props {}
 
@@ -9,7 +11,13 @@ const ReviewContainerHeader: React.FC<Props> = ({}) => {
   return (
     <Wrapper>
       <Title>리뷰{lengthOfReviews > 0 && ` (${lengthOfReviews})`}</Title>
-      <button>리뷰 작성하기</button>
+      <AwesomeButton>
+        <ButtonInner>
+          <FaPencilAlt />
+          리뷰 작성하기
+          <FaPencilAlt />
+        </ButtonInner>
+      </AwesomeButton>
     </Wrapper>
   );
 };
@@ -22,6 +30,11 @@ const Wrapper = styled.div`
 
 const Title = styled.div`
   font-size: 2rem;
+`;
+
+const ButtonInner = styled.div`
+  display: flex;
+  gap: 1rem;
 `;
 
 export default ReviewContainerHeader;

--- a/frontend/client/src/components/ReviewContainerHeader/ReviewContainerHeader.tsx
+++ b/frontend/client/src/components/ReviewContainerHeader/ReviewContainerHeader.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props {}
+
+const ReviewContainerHeader: React.FC<Props> = ({}) => {
+  const lengthOfReviews = 4;
+
+  return (
+    <Wrapper>
+      <Title>리뷰{lengthOfReviews > 0 && ` (${lengthOfReviews})`}</Title>
+      <button>리뷰 작성하기</button>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
+const Title = styled.div`
+  font-size: 2rem;
+`;
+
+export default ReviewContainerHeader;

--- a/frontend/client/src/components/ReviewList/ReviewList.tsx
+++ b/frontend/client/src/components/ReviewList/ReviewList.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import ReviewCard from '../ReviewCard/ReviewCard';
+
+interface Props {}
+// reviews: Review[];
+
+const ReviewList: React.FC<Props> = ({}) => {
+  return (
+    <Wrapper>
+      <ReviewListItemWrapper>
+        <ReviewCard />
+      </ReviewListItemWrapper>
+      <ReviewListItemWrapper>
+        <ReviewCard />
+      </ReviewListItemWrapper>
+      <ReviewListItemWrapper>
+        <ReviewCard />
+      </ReviewListItemWrapper>
+    </Wrapper>
+  );
+};
+
+// 시멘틱 html tag를 준수하였습니다.
+const Wrapper = styled.ul``;
+
+const ReviewListItemWrapper = styled.li`
+  padding: 2rem 0rem 3rem 0rem;
+  border-bottom: 1px dashed ${(props) => props.theme.placeholder};
+`;
+
+export default ReviewList;

--- a/frontend/client/src/components/Star/Star.tsx
+++ b/frontend/client/src/components/Star/Star.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { BsStarFill } from 'react-icons/bs';
+import { useTheme } from 'styled-components';
+
+interface StarProps {
+  isFilled?: boolean;
+}
+
+const Star: React.FC<StarProps> = ({ isFilled }) => {
+  const theme = useTheme() as any;
+  /*
+  아 이거 난처하네요...
+  useTheme가 styled-components에서 제공하는 훅인데 반환값의 타입이 빈 객체라서 프로퍼티 접근을 타입스크립트가 막아버리네요...
+  흠...
+  */
+
+  return <BsStarFill color={isFilled ? theme.primary : theme.placeholder} />;
+};
+
+export default Star;


### PR DESCRIPTION
# 리뷰 컨테이너 목업입니다. 데이터 흐름을 작성하기 전에 PR하면 좋을 것 같아서 올립니다.

## 특이 사항은 없습니다! 그냥 기본적인 컴포넌트 입니다.  응원의 말씀과 함께 어프루브를 주십시오.

## 계층은 다음과 같습니다.

- [x] 리뷰 헤더 (리뷰 개수)
- [x] 리뷰 작성하기 버튼
- [x] 리뷰 리스트
  - [x] 리뷰 아이템
    - [x] 프로필 아바타
    - [x] 유저이름
    - [x] 별점
    - [x] 작성시각
    - [x] 수정/삭제 버튼 (조건부 렌더링)
      - [ ] 삭제 모달     
    - [x] 상품 정보(제목)
    - [x] 이미지 리스트
      - [ ] 이미지 크게 보기 모달
        - [ ] 좌우 버튼
        - [ ] 이미지
    - [x] 리뷰 내용
- [x] 페이지네이션
- [ ] NoData렌더링
- [ ] Loading 렌더링

## 리뷰 컨테이너 컴포넌트 렌더링한 모습

![스크린샷 2021-08-24 오후 10 06 28](https://user-images.githubusercontent.com/64543699/130621850-a56f4832-0e51-460f-ac74-1fbf1644058a.png)