### PR TITLE
[feature/195] 주문 상세 보기 모달 추가 및 여러 모달 BlurBackground 클릭시 닫히도록 수정

### DIFF
--- a/frontend/admin/src/components/Header/DashboardIcon/DashboardIcon.tsx
+++ b/frontend/admin/src/components/Header/DashboardIcon/DashboardIcon.tsx
@@ -35,6 +35,7 @@ export const HeaderIconContainer = styled('div')<IconContainerProps>`
 
 export const HeaderIconTitle = styled('span')`
   margin-left: 12px;
+  user-select: none;
 `;
 
 export default DashboardIcon;

--- a/frontend/admin/src/components/Header/GoodsAdminIcon/GoodsAdminIcon.tsx
+++ b/frontend/admin/src/components/Header/GoodsAdminIcon/GoodsAdminIcon.tsx
@@ -33,6 +33,7 @@ export const HeaderIconContainer = styled('div')<IconContainerProps>`
 
 export const HeaderIconTitle = styled('span')`
   margin-left: 12px;
+  user-select: none;
 `;
 
 export default GoodsAdminIcon;

--- a/frontend/admin/src/components/Header/LogoIcon/LogoIcon.tsx
+++ b/frontend/admin/src/components/Header/LogoIcon/LogoIcon.tsx
@@ -21,6 +21,7 @@ const LogoContainer = styled('div')`
 
 const Logo = styled('img')`
   width: 100%;
+  user-select: none;
 `;
 
 export default LogoIcon;

--- a/frontend/admin/src/components/Header/OrderAdminIcon/OrderAdminIcon.tsx
+++ b/frontend/admin/src/components/Header/OrderAdminIcon/OrderAdminIcon.tsx
@@ -32,6 +32,7 @@ export const HeaderIconContainer = styled('div')<IconContainerProps>`
 
 export const HeaderIconTitle = styled('span')`
   margin-left: 12px;
+  user-select: none;
 `;
 
 export default OrderAdminIcon;

--- a/frontend/admin/src/components/Header/PromotionAdminIcon/PromotionAdminIcon.tsx
+++ b/frontend/admin/src/components/Header/PromotionAdminIcon/PromotionAdminIcon.tsx
@@ -33,6 +33,7 @@ export const HeaderIconContainer = styled('div')<IconContainerProps>`
 
 export const HeaderIconTitle = styled('span')`
   margin-left: 12px;
+  user-select: none;
 `;
 
 export default PromotionAdminIcon;

--- a/frontend/admin/src/hooks/useInterval.ts
+++ b/frontend/admin/src/hooks/useInterval.ts
@@ -20,7 +20,7 @@ const useInterval: IntervalHook = (callback, delay) => {
         clearInterval(id);
       };
     }
-  }, [callback, delay]);
+  }, [delay]);
 };
 
 export default useInterval;

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsAdmin.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsAdmin.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { styled } from '@src/lib/CustomStyledComponent';
 import GoodsTable from './GoodsTable/GoodsTable';
 import GoodsUploadModal from '@src/portal/GoodsUploadModal/GoodsUploadModal';
+import { theme } from '@src/theme/theme';
+import { styled } from '@src/lib/CustomStyledComponent';
 
 const GoodsAdmin = () => {
   const [openUploadModal, setOpenUploadModal] = useState(false);
@@ -26,7 +27,8 @@ const GoodsAdmin = () => {
 const GoodsAdminContainer = styled('div')`
   width: 100%;
   position: relative;
-  margin: 5rem;
+  padding: 5rem;
+  background-color: ${(_) => theme.dustWhite};
 `;
 
 const GoodsAdminHeader = styled('div')`

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
@@ -25,6 +25,7 @@ const GoodsTableRow: React.FC<Props> = ({ goods, handleUpdateGoods }) => {
     goods;
   return (
     <GoodsTableRowContainer onClick={() => handleUpdateGoods(goods)}>
+      <TableData>{goods.id}</TableData>
       <TableData>
         <ThumbnailImg src={thumbnailUrl} />
       </TableData>

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
@@ -10,6 +10,7 @@ const GoodsTableHead = () => {
     // TODO: 컴포넌트화
     <GoodsTableHeadContainer>
       <TableRow>
+        <TableHeadData>상품 ID</TableHeadData>
         <TableHeadData>썸네일</TableHeadData>
         <TableHeadData>
           <SortButton onClick={handleSortGoods}>

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard.tsx
@@ -4,14 +4,21 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface LiveOrderCardProps {
+  onClickOrder: (order: Order) => void;
   order: Order;
 }
 
-const LiveOrderCard: React.FC<LiveOrderCardProps> = ({ order }) => {
+const LiveOrderCard: React.FC<LiveOrderCardProps> = ({ order, onClickOrder }) => {
   const { id, orderItems, user, createdAt } = order;
   const firstOrderItems = orderItems[0];
+
+  const handleClickCard = (e: React.MouseEvent) => {
+    onClickOrder(order);
+    e.stopPropagation();
+  };
+
   return (
-    <div>
+    <div onClick={handleClickCard}>
       <LiveOrderTitle>{convertYYYYMMDDHHMMSS(new Date(createdAt))}</LiveOrderTitle>
       <LiveOrderCardContainer key={id}>
         <img width={50} height={50} src={firstOrderItems.goods.thumbnailUrl} />

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -2,6 +2,7 @@ import { getAllOrders } from '@src/apis/orderAPI';
 import useInterval from '@src/hooks/useInterval';
 import { styled } from '@src/lib/CustomStyledComponent';
 import LiveOrderCard from '@src/pages/Main/LiveOrderList/LiveOrderCard/LiveOrderCard';
+import OrderModal from '@src/portal/OrderModal/OrderModal';
 import { theme } from '@src/theme/theme';
 import { Order } from '@src/types/Order';
 import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
@@ -13,6 +14,8 @@ const POLLING_INTERVAL_MILLISECONDS = 2000;
 
 const LiveOrderList = () => {
   const [updateTime, setUpdateTime] = useState<Date>(new Date());
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [isOpenOrderModal, setIsOpenOrderModal] = useState<boolean>(false);
   const [orders, setOrder] = useState<Order[]>([]);
 
   const updateOrders = useCallback(async () => {
@@ -33,6 +36,12 @@ const LiveOrderList = () => {
 
   useInterval(updateOrders, POLLING_INTERVAL_MILLISECONDS); // 1초마다 폴링
 
+  const handleCloseModal = () => setIsOpenOrderModal(false);
+  const handleClickOrder = (order: Order) => {
+    setIsOpenOrderModal(true);
+    setSelectedOrder(order);
+  };
+
   return (
     <LiveOrderListContainer>
       <LiveOrderListTitle color={theme.greenColor}>주문 현황</LiveOrderListTitle>
@@ -41,9 +50,10 @@ const LiveOrderList = () => {
       </LatestUpdateTime>
       <LiveOrderItemContainer>
         {orders.map((order) => (
-          <LiveOrderCard key={order.id} order={order} />
+          <LiveOrderCard key={order.id} order={order} onClickOrder={handleClickOrder} />
         ))}
       </LiveOrderItemContainer>
+      {isOpenOrderModal && selectedOrder && <OrderModal onClose={handleCloseModal} order={selectedOrder} />}
     </LiveOrderListContainer>
   );
 };

--- a/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT_ORDER = 10;
 
 const OrderAdmin = () => {
   const [isOpenOrderModal, setIsOpenOrderModal] = useState(false);
-
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
@@ -41,6 +41,7 @@ const OrderAdmin = () => {
 
   const handleClickOrder = (order: Order) => {
     setIsOpenOrderModal(true);
+    setSelectedOrder(order);
   };
 
   return (
@@ -65,7 +66,7 @@ const OrderAdmin = () => {
         />
       )}
 
-      {isOpenOrderModal && <OrderModal onClose={handleCloseModal} />}
+      {isOpenOrderModal && selectedOrder && <OrderModal onClose={handleCloseModal} order={selectedOrder} />}
     </OrderAdminContainer>
   );
 };

--- a/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderAdmin.tsx
@@ -2,6 +2,8 @@ import { getAllOrders } from '@src/apis/orderAPI';
 import Loading from '@src/components/Loading/Loading';
 import Paginator from '@src/components/Paginator/Paginator';
 import OrderTable from '@src/pages/OrderAdmin/OrderTable/OrderTable';
+import OrderModal from '@src/portal/OrderModal/OrderModal';
+import { theme } from '@src/theme/theme';
 import { Order, OrderPaginationResult } from '@src/types/Order';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -10,6 +12,8 @@ const DEFAULT_START_PAGE = 0;
 const DEFAULT_LIMIT_ORDER = 10;
 
 const OrderAdmin = () => {
+  const [isOpenOrderModal, setIsOpenOrderModal] = useState(false);
+
   const [orderPaginationResult, setOrderPaginationResult] = useState<OrderPaginationResult | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [currentPage, setCurrentPage] = useState(DEFAULT_START_PAGE);
@@ -31,6 +35,14 @@ const OrderAdmin = () => {
     fetchOrders();
   }, [currentPage]);
 
+  const handleCloseModal = () => {
+    setIsOpenOrderModal(false);
+  };
+
+  const handleClickOrder = (order: Order) => {
+    setIsOpenOrderModal(true);
+  };
+
   return (
     <OrderAdminContainer>
       <TitleSection>
@@ -39,7 +51,11 @@ const OrderAdmin = () => {
         <span>{errorMessage}</span>
       </TitleSection>
 
-      {orderPaginationResult ? <OrderTable orderList={orderPaginationResult.orderList} /> : <Loading />}
+      {orderPaginationResult ? (
+        <OrderTable orderList={orderPaginationResult.orderList} onClickOrder={handleClickOrder} />
+      ) : (
+        <Loading />
+      )}
 
       {orderPaginationResult && (
         <Paginator
@@ -48,6 +64,8 @@ const OrderAdmin = () => {
           setPage={setCurrentPage}
         />
       )}
+
+      {isOpenOrderModal && <OrderModal onClose={handleCloseModal} />}
     </OrderAdminContainer>
   );
 };
@@ -55,7 +73,8 @@ const OrderAdmin = () => {
 const OrderAdminContainer = styled('div')`
   position: relative;
   width: 100%;
-  margin: 5rem;
+  padding: 5rem;
+  background-color: ${theme.dustWhite};
 `;
 
 const Title = styled('h2')`

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTable.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTable.tsx
@@ -5,21 +5,21 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface OrderTableProps {
+  onClickOrder: (order: Order) => void;
   orderList: Order[];
 }
 
-const OrderTable: React.FC<OrderTableProps> = ({ orderList }) => {
+const OrderTable: React.FC<OrderTableProps> = ({ orderList, onClickOrder }) => {
   return (
     <OrderTableContainer>
       <OrderTableHead />
-      <OrderTableBody orderList={orderList} />
+      <OrderTableBody orderList={orderList} onClickOrder={onClickOrder} />
     </OrderTableContainer>
   );
 };
 
 const OrderTableContainer = styled.div`
   width: 100%;
-  min-height: 650px;
 `;
 
 export default OrderTable;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderRow.tsx
@@ -5,13 +5,17 @@ import { Order } from '@src/types/Order';
 import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
 
 interface OrderRowProps {
+  onClickOrder: (order: Order) => void;
   order: Order;
 }
 
-const OrderRow: React.FC<OrderRowProps> = ({ order }) => {
-  const firstGoods = order.orderItems[0];
+const OrderRow: React.FC<OrderRowProps> = ({ order, onClickOrder }) => {
+  const handleClickRow = (e: React.MouseEvent) => {
+    onClickOrder(order);
+  };
+
   return (
-    <OrderRowContainer>
+    <OrderRowContainer onClick={handleClickRow}>
       <OrderRowCell>
         <p>{order.id}</p>
       </OrderRowCell>
@@ -76,7 +80,6 @@ const OrderUserRowCell = styled('div')`
 
 const UserThumbnailImg = styled('img')`
   border-radius: 50%;
-  border: 1px solid #c0c0c0;
   width: 50px;
   height: 50px;
   object-fit: contain;

--- a/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableBody.tsx
+++ b/frontend/admin/src/pages/OrderAdmin/OrderTable/OrderTableBody/OrderTableBody.tsx
@@ -4,14 +4,15 @@ import { Order } from '@src/types/Order';
 import React from 'react';
 
 interface OrderTableBodyProps {
+  onClickOrder: (order: Order) => void;
   orderList: Order[];
 }
 
-const OrderTableBody: React.FC<OrderTableBodyProps> = ({ orderList }) => {
+const OrderTableBody: React.FC<OrderTableBodyProps> = ({ orderList, onClickOrder }) => {
   return (
     <OrderTableBodyContainer>
       {orderList.map((order) => (
-        <OrderRow key={order.id} order={order} />
+        <OrderRow key={order.id} order={order} onClickOrder={onClickOrder} />
       ))}
     </OrderTableBodyContainer>
   );

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
@@ -49,7 +49,7 @@ const PromotionAdmin = () => {
 const PromotionAdminContainer = styled('div')`
   position: relative;
   width: 100%;
-  min-width: 1080px;
+  min-width: 1280px;
 `;
 
 const PromotionCounterContainer = styled('div')`

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
@@ -52,16 +52,17 @@ const PromotionItem: React.FC<Props> = ({ promotion, onDeletePromotion }) => {
 
 const PromotionContainer = styled('div')`
   position: relative;
-  padding: 25px;
-  width: 50%;
-  height: 400px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  width: 100%;
+  height: 350px;
   min-width: 440px;
   min-height: 320px;
 `;
 
 const PromotionImage = styled('img')`
   width: 100%;
-  height: 250px;
+  height: 300px;
   border-radius: 20px;
 `;
 

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
@@ -35,14 +35,16 @@ const PromotionListContainer = styled('ul')`
   border: 1px solid lightgray;
   border-radius: 16px;
 `;
+
 const PromotionAddButtonContainer = styled('div')`
   position: relative;
-  padding: 25px;
-  width: 50%;
+  padding: 10px;
+  width: 100%;
   height: 400px;
   min-width: 440px;
   min-height: 320px;
 `;
+
 const PromotionAddButton = styled('button')`
   position: relative;
   font-size: 2em;

--- a/frontend/admin/src/portal/ConfirmModal/ConfirmModal.tsx
+++ b/frontend/admin/src/portal/ConfirmModal/ConfirmModal.tsx
@@ -10,8 +10,8 @@ interface Props {
 const ConfirmModal: React.FC<Props> = ({ title, onConfirm, onClose }) => {
   return (
     <Portal>
-      <ConfirmModalContainer>
-        <ConfirmContent>
+      <ConfirmModalContainer onClick={() => onClose()}>
+        <ConfirmContent onClick={(e) => e.stopPropagation()}>
           <ConfirmTitleContainer>
             <ConfirmTitle>{title}</ConfirmTitle>
           </ConfirmTitleContainer>

--- a/frontend/admin/src/portal/GoodsUploadModal/GoodsUploadModal.tsx
+++ b/frontend/admin/src/portal/GoodsUploadModal/GoodsUploadModal.tsx
@@ -142,8 +142,8 @@ const GoodsUploadModal: React.FC<Props> = ({ onClose, goods }) => {
   }, []);
   return (
     <Portal>
-      <ModalContainer>
-        <ProductUploadContainer>
+      <ModalContainer onClick={() => onClose()}>
+        <ProductUploadContainer onClick={(e) => e.stopPropagation()}>
           <ProductImageUploader
             onHandleUpdateFiles={handleUpdateFiles}
             onHandleDeleteFile={handleDeleteFile}

--- a/frontend/admin/src/portal/OrderModal/OrderCard.tsx
+++ b/frontend/admin/src/portal/OrderModal/OrderCard.tsx
@@ -96,7 +96,7 @@ const OrderTimeSection = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   width: 50%;
 `;
 
@@ -104,7 +104,7 @@ const OrderUserSection = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   width: 50%;
 `;
 

--- a/frontend/admin/src/portal/OrderModal/OrderCard.tsx
+++ b/frontend/admin/src/portal/OrderModal/OrderCard.tsx
@@ -1,0 +1,200 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import OrderItemCard from '@src/portal/OrderModal/OrderGoods';
+import { Order } from '@src/types/Order';
+import { convertYYYYMMDDHHMMSS } from '@src/utils/dateHelper';
+import React from 'react';
+import { AiFillHome } from 'react-icons/ai';
+import { FaBoxes } from 'react-icons/fa';
+import { GiMatterStates } from 'react-icons/gi';
+import { MdPayment } from 'react-icons/md';
+
+interface OrderCard {
+  order: Order;
+}
+const OrderCard: React.FC<OrderCard> = ({ order }) => {
+  return (
+    <OrderCardContainer>
+      <OrderCardContainerHeader>
+        <OrderTimeSection>
+          <TitleLabel>주문 일시</TitleLabel>
+          <div>발생: {convertYYYYMMDDHHMMSS(new Date(order.createdAt))}</div>
+          <div>수정: {convertYYYYMMDDHHMMSS(new Date(order.updatedAt))}</div>
+        </OrderTimeSection>
+        <OrderUserSection>
+          <TitleLabel>고객 정보</TitleLabel>
+          <UserProfileImg src={order.user.profileImgUrl} />
+          <UserProfileName>{order.user.name}</UserProfileName>
+        </OrderUserSection>
+      </OrderCardContainerHeader>
+
+      <OrderCardContainerBody>
+        <OrderGoodsSection>
+          <TitleLabel>
+            <FaBoxes />
+            주문 상품들
+          </TitleLabel>
+          <OrderItemCardList>
+            {order.orderItems.map((orderItem) => (
+              <OrderItemCard orderItem={orderItem} />
+            ))}
+          </OrderItemCardList>
+        </OrderGoodsSection>
+        <OrderInfoSection>
+          <DeliverySection>
+            <TitleLabel>
+              <AiFillHome /> 배송지
+            </TitleLabel>
+            <DeliveryInfo>
+              <DeliveryInfoLabel>받는 사람</DeliveryInfoLabel>
+              <p>{order.receiver}</p>
+              <DeliveryInfoLabel>주소</DeliveryInfoLabel>
+              <p>{order.address}</p>
+              <DeliveryInfoLabel>상세 주소</DeliveryInfoLabel>
+              <p>{order.subAddress}</p>
+              <DeliveryInfoLabel>ZIP Code</DeliveryInfoLabel>
+              <p>{order.zipCode}</p>
+            </DeliveryInfo>
+          </DeliverySection>
+          <OrderStateSection>
+            <TitleLabel>
+              <GiMatterStates /> 주문 상태
+            </TitleLabel>
+            <OrderState>{order.state}</OrderState>
+          </OrderStateSection>
+          <PaymentSection>
+            <TitleLabel>
+              <MdPayment /> 결제 수단
+            </TitleLabel>
+            <PaymentInfo>
+              <PaymentInfoLabel>결제 방식</PaymentInfoLabel>
+              <p>{order.payment.type}</p>
+            </PaymentInfo>
+          </PaymentSection>
+        </OrderInfoSection>
+      </OrderCardContainerBody>
+    </OrderCardContainer>
+  );
+};
+
+const OrderCardContainer = styled('div')`
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const OrderCardContainerHeader = styled('div')`
+  display: flex;
+  width: 100%;
+  height: 20%;
+`;
+
+const OrderTimeSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 50%;
+`;
+
+const OrderUserSection = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 50%;
+`;
+
+const OrderCardContainerBody = styled('div')`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  height: 80%;
+`;
+
+const OrderGoodsSection = styled('div')`
+  width: 70%;
+  height: 100%;
+`;
+
+const OrderItemCardList = styled('ul')`
+  display: flex;
+  padding: 1rem;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 90%;
+  border: 1px solid #c0c0c0;
+  border-radius: 16px;
+  overflow: scroll;
+`;
+
+const OrderInfoSection = styled('div')`
+  width: 25%;
+  height: 100%;
+`;
+
+const DeliverySection = styled('div')`
+  min-height: 40%;
+`;
+
+const DeliveryInfo = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 1px solid #c0c0c0;
+  border-radius: 16px;
+  padding: 1rem;
+`;
+
+const DeliveryInfoLabel = styled('label')`
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.5rem;
+`;
+
+const OrderStateSection = styled('div')`
+  height: 20%;
+`;
+
+const OrderState = styled('div')`
+  border: 1px solid #c0c0c0;
+  border-radius: 16px;
+  padding: 1rem;
+`;
+
+const PaymentSection = styled('div')`
+  height: 20%;
+`;
+
+const PaymentInfo = styled('div')`
+  border: 1px solid #c0c0c0;
+  border-radius: 16px;
+  padding: 1rem;
+`;
+
+const PaymentInfoLabel = styled('label')`
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.5rem;
+`;
+
+const TitleLabel = styled('div')`
+  font-size: 1.5rem;
+  padding: 1rem;
+`;
+
+const UserProfileImg = styled('img')`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  object-fit: contain;
+`;
+
+const UserProfileName = styled('p')`
+  font-size: 1rem;
+  font-weight: 600;
+`;
+
+export default OrderCard;

--- a/frontend/admin/src/portal/OrderModal/OrderGoods.tsx
+++ b/frontend/admin/src/portal/OrderModal/OrderGoods.tsx
@@ -1,0 +1,35 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import { OrderItem } from '@src/types/Order';
+import { getPriceText } from '@src/utils/price';
+import React from 'react';
+
+interface OrderItemCardProps {
+  orderItem: OrderItem;
+}
+const OrderItemCard: React.FC<OrderItemCardProps> = ({ orderItem }) => {
+  const { goods, amount, price, state } = orderItem;
+
+  return (
+    <OrderGoodsContainer>
+      <div>{goods.id}</div>
+      <GoodsThumbnail src={goods.thumbnailUrl} />
+      <div>{goods.title}</div>
+      <div>수량: {amount} 개 </div>
+      <div>금액: {getPriceText(price)} 원</div>
+      <div>상태: {state}</div>
+    </OrderGoodsContainer>
+  );
+};
+
+const OrderGoodsContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const GoodsThumbnail = styled('img')`
+  width: 50px;
+  height: 50px;
+`;
+
+export default OrderItemCard;

--- a/frontend/admin/src/portal/OrderModal/OrderModal.tsx
+++ b/frontend/admin/src/portal/OrderModal/OrderModal.tsx
@@ -1,12 +1,16 @@
 import { styled } from '@src/lib/CustomStyledComponent';
+import OrderCard from '@src/portal/OrderModal/OrderCard';
 import Portal from '@src/portal/portal';
+import { Order } from '@src/types/Order';
 import React from 'react';
+import { FaTimes } from 'react-icons/fa';
 
 interface OrderModalInterface {
+  order: Order;
   onClose: () => void;
 }
 
-const OrderModal: React.FC<OrderModalInterface> = ({ onClose }) => {
+const OrderModal: React.FC<OrderModalInterface> = ({ order, onClose }) => {
   const handleClickBlurBg = () => {
     onClose();
   };
@@ -18,7 +22,12 @@ const OrderModal: React.FC<OrderModalInterface> = ({ onClose }) => {
   return (
     <Portal>
       <ModalContainer onClick={handleClickBlurBg}>
-        <OrderModalContent onClick={handleClickContent}>TEST</OrderModalContent>
+        <OrderModalContent onClick={handleClickContent}>
+          <OrderCard order={order} />
+          <CloseButton onClick={() => onClose()}>
+            <FaTimes />
+          </CloseButton>
+        </OrderModalContent>
       </ModalContainer>
     </Portal>
   );
@@ -41,11 +50,27 @@ const OrderModalContent = styled('div')`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  height: 40%;
-  width: 40%;
+  height: 800px;
+  width: 1000px;
   margin: auto;
   background-color: white;
   border-radius: 8px;
+`;
+
+const CloseButton = styled('button')`
+  position: absolute;
+  top: -0.5rem;
+  right: -0.5rem;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  font-size: 1.8em;
+  border-radius: 50%;
+  background-color: #2ac1bc;
+  color: white;
+  border: none;
+  cursor: pointer;
 `;
 
 export default OrderModal;

--- a/frontend/admin/src/portal/OrderModal/OrderModal.tsx
+++ b/frontend/admin/src/portal/OrderModal/OrderModal.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@src/lib/CustomStyledComponent';
+import Portal from '@src/portal/portal';
+import React from 'react';
+
+interface OrderModalInterface {
+  onClose: () => void;
+}
+
+const OrderModal: React.FC<OrderModalInterface> = ({ onClose }) => {
+  const handleClickBlurBg = () => {
+    onClose();
+  };
+
+  const handleClickContent = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <Portal>
+      <ModalContainer onClick={handleClickBlurBg}>
+        <OrderModalContent onClick={handleClickContent}>TEST</OrderModalContent>
+      </ModalContainer>
+    </Portal>
+  );
+};
+
+const ModalContainer = styled('div')`
+  position: fixed;
+  z-index: 1000;
+  text-align: center;
+  background-color: #00000020;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const OrderModalContent = styled('div')`
+  z-index: 1005;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: 40%;
+  width: 40%;
+  margin: auto;
+  background-color: white;
+  border-radius: 8px;
+`;
+
+export default OrderModal;

--- a/frontend/admin/src/portal/PromotionUploadModal/PromotionUploadModal.tsx
+++ b/frontend/admin/src/portal/PromotionUploadModal/PromotionUploadModal.tsx
@@ -57,8 +57,8 @@ const PromotionUploadModal: React.FC<Props> = ({ updatePromotions, onClose }) =>
 
   return (
     <Portal>
-      <ModalContainer>
-        <PromotionUploadContainer>
+      <ModalContainer onClick={() => onClose()}>
+        <PromotionUploadContainer onClick={(e) => e.stopPropagation()}>
           <PositionContainer>
             <PromotionImageUploader onUploadFile={handleUploadFile} />
             <GoodsSearchInput onUpdateSelectedGoods={handleSelectedGoods} />

--- a/frontend/admin/webpack.dev.js
+++ b/frontend/admin/webpack.dev.js
@@ -7,12 +7,11 @@ module.exports = merge(common, {
   devtool: 'inline-source-map',
 
   devServer: {
-    publicPath: '/',
     overlay: true,
     port: 8082,
     stats: 'errors-only',
     historyApiFallback: {
-      index: '/dist/admin_index.html',
+      index: '/admin_index.html',
     },
     proxy: {
       '/api': 'http://localhost:8080',


### PR DESCRIPTION
## :bookmark_tabs: 제목

주문을 상세 조회하기 위해서 관리자페이지에서 주문 상세보기 모달을 추가했습니다. 그리고 관리자페이지지에서 모달들이 blur background를 클릭시 닫히도록 코드 수정을 진행했습니다.

![모달](https://user-images.githubusercontent.com/20085849/130711519-3907153b-2fe4-448d-9baa-63418962f2b0.gif)


## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 주문 아이템 클릭시 주문상세보기 모달으로 보여주기
- [ ]  프로모션 관라페이지에서 넓이 수정
- [ ] 대시보드에서 주문 아이템 클릭시 상세보기 모달 띄우기

