### PR TITLE
[feature/199] 관리자 페이지 상품 정렬 기능 추가 및 대시보드, 프로모션 관리 UI 수정

### DIFF
--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -72,10 +72,11 @@ async function getGoodsDetail(req: Request, res: Response) {
 }
 
 async function getAllGoodsForClient(req: Request, res: Response) {
-  const { page, limit, flag, category, keyword } = req.query;
+  const { page, limit, flag, category, keyword, sort } = req.query;
   const query: GetAllGoodsQuery = {
     page: Number(page),
     limit: Number(limit),
+    sort: String(sort),
   };
   if (category) query.category = String(category);
   if (flag) query.flag = String(flag);
@@ -87,12 +88,14 @@ async function getAllGoodsForClient(req: Request, res: Response) {
 }
 
 async function getAllGoodsForAdmin(req: Request, res: Response) {
-  const { page, limit, keyword } = req.query;
+  const { page, limit, flag, keyword, sort } = req.query;
   const query: GetAllGoodsQuery = {
     page: Number(page),
     limit: Number(limit),
+    sort: String(sort),
   };
   if (keyword) query.keyword = String(keyword);
+  if (flag) query.flag = String(flag);
   const userId = req.session.userId;
   const isAdmin = true;
   const result = await GoodsService.getGoodsByOption(query, isAdmin, userId);

--- a/backend/src/controller/goods.controller.ts
+++ b/backend/src/controller/goods.controller.ts
@@ -37,7 +37,9 @@ async function createGoods(req: CreateGoodsRequest, res: Response) {
 
 async function updateGoods(req: UpdateGoodsRequest, res: Response) {
   const goodsId = Number(req.params.id);
-  const { title, isGreen, stock, state, price, discountRate, category, deliveryInfo, oldImages } = req.body;
+  const { title, isGreen, stock, state, price, discountRate, category, deliveryInfo, thumbnailUrl, oldImages } =
+    req.body;
+
   const body: UpdateGoodsBody = {
     title,
     isGreen: Boolean(isGreen),
@@ -48,6 +50,7 @@ async function updateGoods(req: UpdateGoodsRequest, res: Response) {
     category: Number(category),
     deliveryInfo: Number(deliveryInfo),
     oldImages,
+    thumbnailUrl,
   };
 
   const files = req.files;

--- a/backend/src/controller/promotion.controller.ts
+++ b/backend/src/controller/promotion.controller.ts
@@ -31,9 +31,15 @@ async function increasePromotionView(req: Request, res: Response) {
   res.sendStatus(204);
 }
 
+async function getPromotionChartData(req: Request, res: Response) {
+  const result = await PromotionService.getPromotionChartData();
+  res.status(200).json({ result });
+}
+
 export const PromotionController = {
   createPromotion,
   getPromotions,
   deletePromotion,
   increasePromotionView,
+  getPromotionChartData,
 };

--- a/backend/src/repository/promotion.repository.ts
+++ b/backend/src/repository/promotion.repository.ts
@@ -20,7 +20,7 @@ async function createPromotion(goodsId: number, imgUrl: string): Promise<Promoti
 async function getPromotions(): Promise<Promotion[]> {
   try {
     const promotionRepo = getRepository(Promotion);
-    return await promotionRepo.find({ order: { createdAt: 'DESC' }, relations: ['goods'] });
+    return await promotionRepo.find({ order: { createdAt: 'DESC' } });
   } catch (err) {
     console.error(err);
     throw new DatabaseError(PROMOTION_DB_ERROR);
@@ -50,9 +50,20 @@ async function increasePromotionView(promotionId: number): Promise<UpdateResult>
   }
 }
 
+async function getPromotionChartData(): Promise<Promotion[]> {
+  try {
+    const promotionRepo = getRepository(Promotion);
+    return await promotionRepo.find({ order: { createdAt: 'DESC' }, relations: ['goods'] });
+  } catch (err) {
+    console.error(err);
+    throw new DatabaseError(PROMOTION_DB_ERROR);
+  }
+}
+
 export const PromotionRepository = {
   createPromotion,
   getPromotions,
   deletePromotion,
   increasePromotionView,
+  getPromotionChartData,
 };

--- a/backend/src/repository/promotion.repository.ts
+++ b/backend/src/repository/promotion.repository.ts
@@ -20,7 +20,7 @@ async function createPromotion(goodsId: number, imgUrl: string): Promise<Promoti
 async function getPromotions(): Promise<Promotion[]> {
   try {
     const promotionRepo = getRepository(Promotion);
-    return await promotionRepo.find({ order: { createdAt: 'DESC' } });
+    return await promotionRepo.find({ order: { createdAt: 'DESC' }, relations: ['goods'] });
   } catch (err) {
     console.error(err);
     throw new DatabaseError(PROMOTION_DB_ERROR);

--- a/backend/src/router/promotion.router.ts
+++ b/backend/src/router/promotion.router.ts
@@ -8,13 +8,11 @@ const PromotionImageFieldName = 'file';
 
 const router = express.Router();
 
+// TODO: 연동 작업 마무리 되면 isAuthenticate 추가
 router.post('/', uploadProductFiles.single(PromotionImageFieldName), wrapAsync(PromotionController.createPromotion));
 router.get('/', wrapAsync(PromotionController.getPromotions));
-
-// TODO: 연동 작업 마무리 되면 isAuthenticate 추가
-router.post('/', uploadProductFiles.single('file'), wrapAsync(PromotionController.createPromotion));
+router.get('/chart', wrapAsync(PromotionController.getPromotionChartData));
 router.delete('/:id', checkNumberInParams, wrapAsync(PromotionController.deletePromotion));
-
 router.patch('/:id', checkNumberInParams, wrapAsync(PromotionController.increasePromotionView));
 
 export default router;

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -9,6 +9,7 @@ import {
   CategoryViewCountResponse,
 } from '../types/response/category.response';
 import { CategoryRepository } from '../repository/category.repository';
+import { isNumber } from '../utils/check.primitive.type';
 
 const BEST_LIST_LENGTH = 5;
 
@@ -95,7 +96,11 @@ async function getCategoryViews(): Promise<CategoryViewCountResponse> {
       categories[item.category.parent] = item.view;
     }
   });
-  await Promise.all(Object.keys(categories).map((key) => pushCategoryViewToList(Number(key), categories[key], result)));
+  await Promise.all(
+    Object.keys(categories)
+      .filter((key) => isNumber(key))
+      .map((key) => pushCategoryViewToList(Number(key), categories[key], result))
+  );
   return result;
 }
 

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -195,22 +195,30 @@ async function getGoodsByOption(
   isAdmin: boolean,
   userId?: number
 ): Promise<GoodsListResponse> {
-  const { page, limit, flag = 'latest', category: categoryName, keyword: title } = query;
-  if (!isNumber(page) || !isNumber(limit) || !flag || (categoryName && !isString(categoryName))) {
+  const { page, limit, flag = 'create', category: categoryName, keyword: title, sort } = query;
+  if (
+    !isNumber(page) ||
+    !isNumber(limit) ||
+    !flag ||
+    (categoryName && !isString(categoryName)) ||
+    (sort !== 'ASC' && sort !== 'DESC')
+  ) {
     throw new BadRequestError(INVALID_DATA);
   }
 
   const GoodsFlag: {
     [keyword: string]: keyof Goods;
   } = {
-    best: 'countOfSell',
-    low: 'price',
-    high: 'price',
-    latest: 'createdAt',
+    title: 'title',
+    price: 'price',
+    discount: 'discountRate',
+    stock: 'stock',
+    sell: 'countOfSell',
+    create: 'createdAt',
+    update: 'updatedAt',
   };
 
   const order = GoodsFlag[flag];
-  const sort = flag === 'low' ? 'ASC' : 'DESC';
   // 관리자는 재고가 0인 상품도 조회 가능
   const stock = isAdmin ? -1 : 0;
   const state = isAdmin ? GoodsStateMap.sale : null;

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -119,7 +119,7 @@ async function updateGoods(body: UpdateGoodsBody, goodsId: number, uploadFileUrl
       deliveryInfo: {
         id: deliveryInfo,
       },
-      thumbnailUrl: oldImages?.length ? thumbnailUrl : uploadFileUrls[0],
+      thumbnailUrl: thumbnailUrl ?? uploadFileUrls[0],
     });
 
     if (oldImages) {

--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -51,7 +51,7 @@ async function createGoods(body: CreateGoodsBody, uploadFileUrls: string[]): Pro
   if (
     !title ||
     isGreen === undefined ||
-    isNaN(body.stock) ||
+    isNumber(body.stock) ||
     !state ||
     isNaN(body.price) ||
     isNaN(body.category) ||
@@ -89,16 +89,17 @@ async function createGoods(body: CreateGoodsBody, uploadFileUrls: string[]): Pro
 
 async function updateGoods(body: UpdateGoodsBody, goodsId: number, uploadFileUrls: string[]): Promise<Goods> {
   await checkValidateCreateGoods(body);
-  const { title, category, isGreen, price, stock, state, discountRate, deliveryInfo, oldImages } = body;
+  const { title, category, isGreen, price, stock, state, discountRate, deliveryInfo, thumbnailUrl, oldImages } = body;
 
   if (
-    !title ||
+    !isString(title) ||
     isGreen === undefined ||
-    isNaN(body.stock) ||
-    !state ||
-    isNaN(body.price) ||
-    isNaN(body.category) ||
-    isNaN(body.deliveryInfo)
+    !isNumber(stock) ||
+    !isString(state) ||
+    !isNumber(price) ||
+    !isNumber(category) ||
+    !isNumber(deliveryInfo) ||
+    (thumbnailUrl && !isString(thumbnailUrl))
   ) {
     throw new BadRequestError(INVALID_DATA);
   }
@@ -118,7 +119,7 @@ async function updateGoods(body: UpdateGoodsBody, goodsId: number, uploadFileUrl
       deliveryInfo: {
         id: deliveryInfo,
       },
-      thumbnailUrl: oldImages ? oldImages[0] : uploadFileUrls[0],
+      thumbnailUrl: oldImages?.length ? thumbnailUrl : uploadFileUrls[0],
     });
 
     if (oldImages) {

--- a/backend/src/service/promotion.service.ts
+++ b/backend/src/service/promotion.service.ts
@@ -15,15 +15,18 @@ async function createPromotion(body: CreatePromotionBody, imgUrl: string): Promi
   return {
     id: newPromotion.id,
     imgUrl: newPromotion.imgUrl,
+    view: newPromotion.view,
   };
 }
 
 async function getPromotions(): Promise<PromotionResponse[]> {
   const promotions = await PromotionRepository.getPromotions();
-
-  return promotions.map((p) => ({
-    id: p.id,
-    imgUrl: p.imgUrl,
+  return promotions.map(({ id, imgUrl, view, goods }) => ({
+    id,
+    imgUrl,
+    view,
+    goodsId: goods.id,
+    title: goods.title,
   }));
 }
 

--- a/backend/src/service/promotion.service.ts
+++ b/backend/src/service/promotion.service.ts
@@ -3,7 +3,7 @@ import { DeleteResult, UpdateResult } from 'typeorm';
 import { BadRequestError } from '../errors/client.error';
 import { PromotionRepository } from '../repository/promotion.repository';
 import { CreatePromotionBody } from '../types/request/promotion.request';
-import { PromotionResponse } from '../types/response/promotion.response';
+import { PromotionChartResponse, PromotionResponse } from '../types/response/promotion.response';
 
 const PROMOTION_PARAMETER_ERROR = '프로모션을 등록하기위해서 imgUrl 값은 필수입니다.';
 const PROMOTION_GOODS_ERROR = '프로모션을 진행하려는 해당 상품은 존재하지 않는 상품입니다.';
@@ -15,19 +15,11 @@ async function createPromotion(body: CreatePromotionBody, imgUrl: string): Promi
   return {
     id: newPromotion.id,
     imgUrl: newPromotion.imgUrl,
-    view: newPromotion.view,
   };
 }
 
 async function getPromotions(): Promise<PromotionResponse[]> {
-  const promotions = await PromotionRepository.getPromotions();
-  return promotions.map(({ id, imgUrl, view, goods }) => ({
-    id,
-    imgUrl,
-    view,
-    goodsId: goods.id,
-    title: goods.title,
-  }));
+  return await PromotionRepository.getPromotions();
 }
 
 async function deletePromotion(promotionId: number): Promise<DeleteResult> {
@@ -45,9 +37,21 @@ async function checkValidateCreatePromotion(body: CreatePromotionBody, imgUrl: s
   if (!imgUrl) throw new BadRequestError(PROMOTION_PARAMETER_ERROR);
 }
 
+async function getPromotionChartData(): Promise<PromotionChartResponse[]> {
+  const promotions = await PromotionRepository.getPromotionChartData();
+  return promotions.map(({ id, imgUrl, view, goods }) => ({
+    id,
+    imgUrl,
+    view,
+    goodsId: goods.id,
+    title: goods.title,
+  }));
+}
+
 export const PromotionService = {
   createPromotion,
   getPromotions,
+  getPromotionChartData,
   deletePromotion,
   increasePromotionView,
 };

--- a/backend/src/types/request/goods.request.ts
+++ b/backend/src/types/request/goods.request.ts
@@ -12,6 +12,7 @@ export interface CreateGoodsBody {
 
 export type UpdateGoodsBody = CreateGoodsBody & {
   oldImages?: string;
+  thumbnailUrl?: string;
 };
 
 export interface CreateGoodsRequest extends Request {

--- a/backend/src/types/request/goods.request.ts
+++ b/backend/src/types/request/goods.request.ts
@@ -26,6 +26,7 @@ export interface UpdateGoodsRequest extends Request {
 export type GetAllGoodsQuery = {
   page: number;
   limit: number;
+  sort: string;
   category?: string;
   flag?: string;
   keyword?: string;

--- a/backend/src/types/response/promotion.response.ts
+++ b/backend/src/types/response/promotion.response.ts
@@ -1,4 +1,10 @@
+import { Goods } from '../../entity/Goods';
+
 export interface PromotionResponse {
   id: number;
   imgUrl: string;
+  view: number;
+  goodsId?: number;
+  title?: string;
+  goods?: Goods;
 }

--- a/backend/src/types/response/promotion.response.ts
+++ b/backend/src/types/response/promotion.response.ts
@@ -3,8 +3,11 @@ import { Goods } from '../../entity/Goods';
 export interface PromotionResponse {
   id: number;
   imgUrl: string;
-  view: number;
-  goodsId?: number;
-  title?: string;
-  goods?: Goods;
 }
+
+export type PromotionChartResponse = PromotionResponse & {
+  view: number;
+  goodsId: number;
+  title: string;
+  goods?: Goods;
+};

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -51,11 +51,11 @@ const getGoodsOptionURL = ({
   page,
   limit = DEFAULT_LIMIT,
   keyword = '',
-  order,
+  flag,
   sort,
 }: GetGoodsByOptionProps): string => {
   return `/api/goods/admin?page=${page}&limit=${limit}${keyword ? `&keyword=${keyword}` : ''}${
-    order ? `&order=${order}` : ''
+    flag ? `&flag=${flag}` : ''
   }${sort ? `&sort=${sort}` : ''}`;
 };
 

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -51,8 +51,8 @@ const getGoodsOptionURL = ({
   page,
   limit = DEFAULT_LIMIT,
   keyword = '',
-  flag,
-  sort,
+  flag = 'create',
+  sort = 'ASC',
 }: GetGoodsByOptionProps): string => {
   return `/api/goods/admin?page=${page}&limit=${limit}${keyword ? `&keyword=${keyword}` : ''}${
     flag ? `&flag=${flag}` : ''

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -23,23 +23,11 @@ const updateGoods = async (formData: FormData, goodsId: number): Promise<APIResp
 
 const DEFAULT_LIMIT = 10;
 
-export const getGoodsByOption = async ({
-  page,
-  limit = DEFAULT_LIMIT,
-  keyword = '',
-  order,
-  sort,
-}: GetGoodsByOptionProps): Promise<APIResponse<GoodsPaginationResult>> => {
-  const res = await checkedFetch(
-    `/api/goods/admin?page=${page}&limit=${limit}
-    ${keyword ? `&keyword=${keyword}` : ''}
-    ${order ? `&order=${order}` : ''}
-    ${sort ? `&sort=${sort}` : ''}`,
-    {
-      method: 'GET',
-      credentials: 'include',
-    }
-  );
+export const getGoodsByOption = async (option: GetGoodsByOptionProps): Promise<APIResponse<GoodsPaginationResult>> => {
+  const res = await checkedFetch(getGoodsOptionURL(option), {
+    method: 'GET',
+    credentials: 'include',
+  });
   return await res.json();
 };
 
@@ -57,6 +45,18 @@ const getBestSellingGoodsForDashboard = async (): Promise<APIResponse<GoodsItem[
     credentials: 'include',
   });
   return await res.json();
+};
+
+const getGoodsOptionURL = ({
+  page,
+  limit = DEFAULT_LIMIT,
+  keyword = '',
+  order,
+  sort,
+}: GetGoodsByOptionProps): string => {
+  return `/api/goods/admin?page=${page}&limit=${limit}${keyword ? `&keyword=${keyword}` : ''}${
+    order ? `&order=${order}` : ''
+  }${sort ? `&sort=${sort}` : ''}`;
 };
 
 export const GoodsAPI = {

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -54,9 +54,10 @@ const getGoodsOptionURL = ({
   flag = 'create',
   sort = 'DESC',
 }: GetGoodsByOptionProps): string => {
-  return `/api/goods/admin?page=${page}&limit=${limit}${keyword ? `&keyword=${keyword}` : ''}${
-    flag ? `&flag=${flag}` : ''
-  }${sort ? `&sort=${sort}` : ''}`;
+  const keywordQuery = keyword ? `&keyword=${keyword}` : '';
+  const flagQuery = flag ? `&flag=${flag}` : '';
+  const sortQuery = sort ? `&sort=${sort}` : '';
+  return `/api/goods/admin?page=${page}&limit=${limit}${keywordQuery + flagQuery + sortQuery}`;
 };
 
 export const GoodsAPI = {

--- a/frontend/admin/src/apis/goodsAPI.ts
+++ b/frontend/admin/src/apis/goodsAPI.ts
@@ -52,7 +52,7 @@ const getGoodsOptionURL = ({
   limit = DEFAULT_LIMIT,
   keyword = '',
   flag = 'create',
-  sort = 'ASC',
+  sort = 'DESC',
 }: GetGoodsByOptionProps): string => {
   return `/api/goods/admin?page=${page}&limit=${limit}${keyword ? `&keyword=${keyword}` : ''}${
     flag ? `&flag=${flag}` : ''

--- a/frontend/admin/src/apis/promotionAPI.ts
+++ b/frontend/admin/src/apis/promotionAPI.ts
@@ -1,5 +1,5 @@
 import { APIResponse, checkedFetch } from '@src/apis/base';
-import { Promotion } from '@src/types/Promotion';
+import { Promotion, PromotionChartData } from '@src/types/Promotion';
 
 const createPromotion = async (formData: FormData): Promise<APIResponse<Promotion>> => {
   const res = await checkedFetch(`/api/promotion`, {
@@ -18,6 +18,14 @@ const getPromotions = async (): Promise<APIResponse<Promotion[]>> => {
   return res.json();
 };
 
+const getPromotionChartData = async (): Promise<APIResponse<PromotionChartData[]>> => {
+  const res = await checkedFetch(`/api/promotion/chart`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  return res.json();
+};
+
 const deletePromotion = async (promotionId: number): Promise<boolean> => {
   const res = await checkedFetch(`/api/promotion/${promotionId}`, {
     method: 'DELETE',
@@ -30,6 +38,7 @@ const deletePromotion = async (promotionId: number): Promise<boolean> => {
 const PromotionAPI = {
   createPromotion,
   getPromotions,
+  getPromotionChartData,
   deletePromotion,
 };
 

--- a/frontend/admin/src/apis/promotionAPI.ts
+++ b/frontend/admin/src/apis/promotionAPI.ts
@@ -1,5 +1,5 @@
 import { APIResponse, checkedFetch } from '@src/apis/base';
-import { Promotion, PromotionChartData } from '@src/types/Promotion';
+import { Promotion } from '@src/types/Promotion';
 
 const createPromotion = async (formData: FormData): Promise<APIResponse<Promotion>> => {
   const res = await checkedFetch(`/api/promotion`, {
@@ -10,15 +10,7 @@ const createPromotion = async (formData: FormData): Promise<APIResponse<Promotio
   return res.json();
 };
 
-const getPromotions = async (): Promise<APIResponse<Promotion[]>> => {
-  const res = await checkedFetch(`/api/promotion`, {
-    method: 'GET',
-    credentials: 'include',
-  });
-  return res.json();
-};
-
-const getPromotionChartData = async (): Promise<APIResponse<PromotionChartData[]>> => {
+const getPromotionsForAdmin = async (): Promise<APIResponse<Promotion[]>> => {
   const res = await checkedFetch(`/api/promotion/chart`, {
     method: 'GET',
     credentials: 'include',
@@ -37,8 +29,7 @@ const deletePromotion = async (promotionId: number): Promise<boolean> => {
 
 const PromotionAPI = {
   createPromotion,
-  getPromotions,
-  getPromotionChartData,
+  getPromotionsForAdmin,
   deletePromotion,
 };
 

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsAdmin.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsAdmin.tsx
@@ -33,7 +33,6 @@ const GoodsAdminContainer = styled('div')`
 
 const GoodsAdminHeader = styled('div')`
   display: flex;
-  align-items: center;
   column-gap: 3rem;
   margin-bottom: 20px;
 `;

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
@@ -43,13 +43,12 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
   };
 
   const setKeyword = (keyword: string) => {
-    setSearchQuery({
+    setSearchQuery((searchQuery) => ({
       ...searchQuery,
       keyword,
-    });
+    }));
   };
 
-  // Q: 굳이 페이지를 1로 초기화할 필요는 없는듯?
   const handleOrderAndSortGoods = (flag: string, sort: 'ASC' | 'DESC') => {
     setSearchQuery({
       ...searchQuery,
@@ -63,7 +62,6 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
   }, []);
 
   useEffect(() => {
-    console.log(searchQuery);
     fetchGoodsList();
   }, [searchQuery, updateGoods]);
 

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
@@ -18,8 +18,6 @@ const LIMIT_COUNT_ITEMS_IN_PAGE = 10;
 const DEFAULT_START_PAGE = 1;
 
 const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
-  // TODO: reducer 적용
-  // const tmp = useReducer(reduce, state);
   const [goodsListMap, setGoodsListMap] = useState<GoodsPaginationResult | null>(null);
   const [openUpdateModal, setOpenUpdateModal] = useState(false);
   const [updateGoods, setUpdateGoods] = useState<GoodsItem | null>(null);
@@ -52,11 +50,20 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
     });
   };
 
+  const handleOrderAndSortGoods = (order: string, sort: 'ASC' | 'DESC') => {
+    setSearchQuery({
+      ...searchQuery,
+      order,
+      sort,
+    });
+  };
+
   const handleUpdateGoods = useCallback((goods: GoodsItem) => {
     setUpdateGoods(goods);
   }, []);
 
   useEffect(() => {
+    console.log(searchQuery);
     fetchGoodsList();
   }, [searchQuery, updateGoods]);
 
@@ -76,7 +83,7 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
     <>
       <Search setKeyword={setKeyword} />
       <GoodsTableContainer>
-        <GoodsTableHead />
+        <GoodsTableHead handleOrderAndSortGoods={handleOrderAndSortGoods} searchQuery={searchQuery} />
         <GoodsTableBody goodsList={goodsListMap.goodsList} handleUpdateGoods={handleUpdateGoods} />
       </GoodsTableContainer>
       <Paginator totalPage={goodsListMap.meta.totalPage} currentPage={goodsListMap.meta.page} setPage={setPage} />

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTable.tsx
@@ -24,7 +24,6 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
   const [searchQuery, setSearchQuery] = useState<GetGoodsByOptionProps>({
     page: DEFAULT_START_PAGE,
     limit: LIMIT_COUNT_ITEMS_IN_PAGE,
-    keyword: '',
   });
 
   const fetchGoodsList = async () => {
@@ -50,10 +49,11 @@ const GoodsTable: React.FC<Props> = ({ openUploadModal }) => {
     });
   };
 
-  const handleOrderAndSortGoods = (order: string, sort: 'ASC' | 'DESC') => {
+  // Q: 굳이 페이지를 1로 초기화할 필요는 없는듯?
+  const handleOrderAndSortGoods = (flag: string, sort: 'ASC' | 'DESC') => {
     setSearchQuery({
       ...searchQuery,
-      order,
+      flag,
       sort,
     });
   };

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableBody.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableBody.tsx
@@ -8,6 +8,7 @@ interface Props {
   handleUpdateGoods: (goods: GoodsItem) => void;
 }
 
+// TODO: 상품목록이 없는 경우 비어있음을 알리는 컴포넌트 추가 (ex: 텅)
 const GoodsTableBody: React.FC<Props> = ({ goodsList, handleUpdateGoods }) => {
   return (
     <GoodsTableBodyContainer>

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableBody/GoodsTableRow/GoodsTableRow.tsx
@@ -4,6 +4,7 @@ import originStyled from 'styled-components';
 import { GoodsItem } from '@src/types/Goods';
 import { getDiscountedPrice, getPriceText } from '@src/utils/price';
 import { convertYYYYMMDD } from '@src/utils/dateHelper';
+import { theme } from '@src/theme/theme';
 
 interface Props {
   goods: GoodsItem;
@@ -21,8 +22,7 @@ const STATE_MAP: StateMap = {
 };
 
 const GoodsTableRow: React.FC<Props> = ({ goods, handleUpdateGoods }) => {
-  const { id, thumbnailUrl, title, price, discountRate, stock, countOfSell, createdAt, updatedAt, state, category } =
-    goods;
+  const { thumbnailUrl, title, price, discountRate, stock, countOfSell, createdAt, updatedAt, state, category } = goods;
   return (
     <GoodsTableRowContainer onClick={() => handleUpdateGoods(goods)}>
       <TableData>{goods.id}</TableData>
@@ -31,7 +31,7 @@ const GoodsTableRow: React.FC<Props> = ({ goods, handleUpdateGoods }) => {
       </TableData>
       <TableData>{title}</TableData>
       <TableData>{getPriceText(price)}원</TableData>
-      <TableData>{discountRate}</TableData>
+      <TableData>{discountRate}%</TableData>
       <TableData>{stock}</TableData>
       <TableData>{countOfSell}</TableData>
       <TableData>{convertYYYYMMDD(new Date(createdAt))}</TableData>

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
@@ -5,7 +5,7 @@ import GoodsTableHeadData from '@src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/
 import { GetGoodsByOptionProps } from '@src/types/Goods';
 
 interface Props {
-  handleOrderAndSortGoods: (order: string, sort: 'ASC' | 'DESC') => void;
+  handleOrderAndSortGoods: (flag: string, sort: 'ASC' | 'DESC') => void;
   searchQuery: GetGoodsByOptionProps;
 }
 
@@ -18,43 +18,39 @@ const GoodsTableHead: React.FC<Props> = ({ handleOrderAndSortGoods, searchQuery 
           text={'상품명'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'title'}
+          flag={'title'}
         />
         <GoodsTableHeadData
           text={'금액'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'price'}
+          flag={'price'}
         />
         <GoodsTableHeadData
           text={'할인율'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'discountRate'}
+          flag={'discount'}
         />
         <GoodsTableHeadData
           text={'재고'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'stock'}
+          flag={'stock'}
         />
         <GoodsTableHeadData
           text={'판매량'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'countOfSell'}
+          flag={'sell'}
         />
         <GoodsTableHeadData
           text={'상품 등록일'}
           searchQuery={searchQuery}
           handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'createdAt'}
+          flag={'create'}
         />
-        <GoodsTableHeadData
-          text={'최종 수정일'}
-          handleOrderAndSortGoods={handleOrderAndSortGoods}
-          order={'updatedAt'}
-        />
+        <GoodsTableHeadData text={'최종 수정일'} handleOrderAndSortGoods={handleOrderAndSortGoods} flag={'update'} />
         <GoodsTableHeadData text={'상태'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
         <GoodsTableHeadData text={'카테고리'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
       </TableRow>

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
@@ -1,61 +1,62 @@
 import React from 'react';
 import { FaAngleDown } from 'react-icons/fa';
 import { styled } from '@src/lib/CustomStyledComponent';
+import GoodsTableHeadData from '@src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData';
+import { GetGoodsByOptionProps } from '@src/types/Goods';
 
-const GoodsTableHead = () => {
-  const handleSortGoods = () => {
-    // TODO: 정렬 관련 처리
-  };
+interface Props {
+  handleOrderAndSortGoods: (order: string, sort: 'ASC' | 'DESC') => void;
+  searchQuery: GetGoodsByOptionProps;
+}
+
+const GoodsTableHead: React.FC<Props> = ({ handleOrderAndSortGoods, searchQuery }) => {
   return (
-    // TODO: 컴포넌트화
     <GoodsTableHeadContainer>
       <TableRow>
-        <TableHeadData>상품 ID</TableHeadData>
-        <TableHeadData>썸네일</TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>상품명</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>가격</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>할인율</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>재고</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>판매량</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>상품 등록일</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>
-          <SortButton onClick={handleSortGoods}>
-            <ButtonText>최종 수정일</ButtonText>
-            <FaAngleDown />
-          </SortButton>
-        </TableHeadData>
-        <TableHeadData>상태</TableHeadData>
-        <TableHeadData>카테고리</TableHeadData>
+        <GoodsTableHeadData text={'썸네일'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
+        <GoodsTableHeadData
+          text={'상품명'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'title'}
+        />
+        <GoodsTableHeadData
+          text={'금액'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'price'}
+        />
+        <GoodsTableHeadData
+          text={'할인율'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'discountRate'}
+        />
+        <GoodsTableHeadData
+          text={'재고'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'stock'}
+        />
+        <GoodsTableHeadData
+          text={'판매량'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'countOfSell'}
+        />
+        <GoodsTableHeadData
+          text={'상품 등록일'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'createdAt'}
+        />
+        <GoodsTableHeadData
+          text={'최종 수정일'}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          order={'updatedAt'}
+        />
+        <GoodsTableHeadData text={'상태'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
+        <GoodsTableHeadData text={'카테고리'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
       </TableRow>
     </GoodsTableHeadContainer>
   );
@@ -68,24 +69,5 @@ const GoodsTableHeadContainer = styled('thead')`
 `;
 
 const TableRow = styled('tr')``;
-
-const TableHeadData = styled('th')`
-  padding: 4px;
-  vertical-align: middle;
-`;
-
-const SortButton = styled('button')`
-  border: 0;
-  font-size: 14px;
-  font-weight: 600;
-  padding: 0.25rem;
-  background-color: transparent;
-  cursor: pointer;
-`;
-
-const ButtonText = styled('span')`
-  display: inline-block;
-  margin-right: 0.25rem;
-`;
 
 export default GoodsTableHead;

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHead.tsx
@@ -50,7 +50,12 @@ const GoodsTableHead: React.FC<Props> = ({ handleOrderAndSortGoods, searchQuery 
           handleOrderAndSortGoods={handleOrderAndSortGoods}
           flag={'create'}
         />
-        <GoodsTableHeadData text={'최종 수정일'} handleOrderAndSortGoods={handleOrderAndSortGoods} flag={'update'} />
+        <GoodsTableHeadData
+          text={'최종 수정일'}
+          searchQuery={searchQuery}
+          handleOrderAndSortGoods={handleOrderAndSortGoods}
+          flag={'update'}
+        />
         <GoodsTableHeadData text={'상태'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
         <GoodsTableHeadData text={'카테고리'} handleOrderAndSortGoods={handleOrderAndSortGoods} />
       </TableRow>

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
@@ -53,7 +53,9 @@ const GoodsTableHeadData: React.FC<Props> = ({ text, flag, handleOrderAndSortGoo
 const GoodsTableHeadDataContainer = styled.th<{ active: boolean }>`
   padding: 4px;
   vertical-align: middle;
-  ${(props) => props.active && `color : ${theme.primary}`}
+  * {
+    ${(props) => props.active && `color : ${theme.primary}`}
+  }
 `;
 
 const SortButton = styled.button`

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { GetGoodsByOptionProps } from '@src/types/Goods';
+import { FaAngleDown, FaAngleUp } from 'react-icons/fa';
+import styled from 'styled-components';
+import { theme } from '@src/theme/theme';
+
+interface Props {
+  text: string;
+  order?: string;
+  handleOrderAndSortGoods: (order: string, sort: Sort) => void;
+  searchQuery?: GetGoodsByOptionProps;
+}
+
+type Sort = 'ASC' | 'DESC';
+
+const ASC = 'ASC';
+const DESC = 'DESC';
+
+const reverseSort = (sort: Sort) => (sort === ASC ? DESC : ASC);
+
+const initialState = (): { active: boolean; sort: Sort } => ({ active: false, sort: ASC });
+
+const GoodsTableHeadData: React.FC<Props> = ({ text, order, handleOrderAndSortGoods, searchQuery }) => {
+  const [sortState, setSortState] = useState(initialState());
+  const handleClick = useCallback(() => {
+    setSortState({ active: true, sort: reverseSort(sortState.sort) });
+  }, [sortState]);
+
+  useEffect(() => {
+    if (order && sortState.active) {
+      handleOrderAndSortGoods(order, sortState.sort);
+    }
+  }, [sortState]);
+
+  useEffect(() => {
+    searchQuery?.order !== order && setSortState(initialState());
+  }, [searchQuery]);
+
+  return (
+    <GoodsTableHeadDataContainer active={sortState.active}>
+      {order ? (
+        <SortButton onClick={handleClick}>
+          <ButtonText>{text}</ButtonText>
+          {sortState.sort === ASC ? <FaAngleDown /> : <FaAngleUp />}
+        </SortButton>
+      ) : (
+        text
+      )}
+    </GoodsTableHeadDataContainer>
+  );
+};
+
+const GoodsTableHeadDataContainer = styled.th<{ active: boolean }>`
+  padding: 4px;
+  vertical-align: middle;
+  ${(props) => props.active && `color : ${theme.primary}`}
+`;
+
+const SortButton = styled.button`
+  border: 0;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 0.25rem;
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const ButtonText = styled.span`
+  display: inline-block;
+  margin-right: 0.25rem;
+`;
+
+export default GoodsTableHeadData;

--- a/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
+++ b/frontend/admin/src/pages/GoodsAdmin/GoodsTable/GoodsTableHead/GoodsTableHeadData/GoodsTableHeadData.tsx
@@ -6,8 +6,8 @@ import { theme } from '@src/theme/theme';
 
 interface Props {
   text: string;
-  order?: string;
-  handleOrderAndSortGoods: (order: string, sort: Sort) => void;
+  flag?: string;
+  handleOrderAndSortGoods: (flag: string, sort: Sort) => void;
   searchQuery?: GetGoodsByOptionProps;
 }
 
@@ -20,25 +20,25 @@ const reverseSort = (sort: Sort) => (sort === ASC ? DESC : ASC);
 
 const initialState = (): { active: boolean; sort: Sort } => ({ active: false, sort: ASC });
 
-const GoodsTableHeadData: React.FC<Props> = ({ text, order, handleOrderAndSortGoods, searchQuery }) => {
+const GoodsTableHeadData: React.FC<Props> = ({ text, flag, handleOrderAndSortGoods, searchQuery }) => {
   const [sortState, setSortState] = useState(initialState());
   const handleClick = useCallback(() => {
     setSortState({ active: true, sort: reverseSort(sortState.sort) });
   }, [sortState]);
 
   useEffect(() => {
-    if (order && sortState.active) {
-      handleOrderAndSortGoods(order, sortState.sort);
+    if (flag && sortState.active) {
+      handleOrderAndSortGoods(flag, sortState.sort);
     }
   }, [sortState]);
 
   useEffect(() => {
-    searchQuery?.order !== order && setSortState(initialState());
+    searchQuery?.flag !== flag && setSortState(initialState());
   }, [searchQuery]);
 
   return (
     <GoodsTableHeadDataContainer active={sortState.active}>
-      {order ? (
+      {flag ? (
         <SortButton onClick={handleClick}>
           <ButtonText>{text}</ButtonText>
           {sortState.sort === ASC ? <FaAngleDown /> : <FaAngleUp />}

--- a/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryBarChart/CategoryBarChart.tsx
@@ -34,7 +34,7 @@ const CategoryBarChart = () => {
 
   return (
     <CategoryBarContainer>
-      <BarChartTitle color={theme.greenColor}>카테고리 조회 수</BarChartTitle>
+      <BarChartTitle color={theme.black5}>카테고리 조회 수</BarChartTitle>
       <ResponsiveContainer width='100%' height='95%'>
         <ComposedChart
           data={categoryViews}
@@ -62,9 +62,8 @@ const CategoryBarContainer = styled('div')`
   padding: 16px;
   width: 50%;
   height: 100%;
-  background-color: whitesmoke;
-  border-radius: 16px;
-  margin-right: 16px;
+  background-color: #fff;
+  border-radius: 6px;
 `;
 
 const BarChartTitle = styled('div')<{ color: string }>`

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -16,6 +16,8 @@ const CategoryPieChart = () => {
     theme.ChartColorOrange,
   ];
 
+  // const COLORS = ['#2F343A', '#E64A45', '#717D8C', '#BDB69C', '#80CEB9', '#41AAC4', '#462066', '#F2C249', '#E6772E'];
+
   useEffect(() => {
     async function fetchChartData() {
       try {

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -62,7 +62,6 @@ const PieChartContainer = styled.div`
   height: 100%;
   background-color: whitesmoke;
   border-radius: 16px;
-  margin-right: 16px;
 `;
 
 const PieChartTitle = styled.span<{ color: string }>`

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -30,7 +30,7 @@ const CategoryPieChart = () => {
 
   return (
     <PieChartContainer>
-      <PieChartTitle color={theme.greenColor}>카테고리 비율</PieChartTitle>
+      <PieChartTitle color={theme.black5}>카테고리 비율</PieChartTitle>
       <ResponsiveContainer width='100%' height='100%'>
         <PieChart>
           <Pie
@@ -60,14 +60,14 @@ const PieChartContainer = styled.div`
   padding: 16px;
   width: 50%;
   height: 100%;
-  background-color: whitesmoke;
-  border-radius: 16px;
+  background-color: #fff;
+  border-radius: 6px;
 `;
 
 const PieChartTitle = styled.span<{ color: string }>`
   position: absolute;
   color: ${(props) => props.color};
-  font-weight: 700;
+  font-weight: 600;
 `;
 
 export default CategoryPieChart;

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -44,8 +44,8 @@ const LiveOrderList = () => {
 
   return (
     <LiveOrderListContainer>
-      <LiveOrderListTitle color={theme.greenColor}>주문 현황</LiveOrderListTitle>
-      <LatestUpdateTime color={theme.greenColor}>
+      <LiveOrderListTitle color={theme.black5}>주문 현황</LiveOrderListTitle>
+      <LatestUpdateTime color={theme.black5}>
         (최근 업데이트 시간: {convertYYYYMMDDHHMMSS(updateTime)})
       </LatestUpdateTime>
       <LiveOrderItemContainer>

--- a/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
+++ b/frontend/admin/src/pages/Main/LiveOrderList/LiveOrderList.tsx
@@ -59,17 +59,16 @@ const LiveOrderList = () => {
 };
 
 const LiveOrderListContainer = styled('div')`
-  margin-left: 16px;
   padding: 16px;
-  background-color: whitesmoke;
-  border-radius: 16px;
+  background-color: #fff;
+  border-radius: 6px;
   height: 100%;
 `;
 
 const LiveOrderListTitle = styled('span')<{ color: string }>`
   color: ${(props) => props.color};
   height: 1.5em;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 16px;
 `;
 

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -40,21 +40,22 @@ const LeftContainer = styled('div')`
   flex-direction: column;
   position: relative;
   width: 60%;
-  height: calc(100% - 2rem);
+  height: 100%;
+  justify-content: space-around;
   row-gap: 2rem;
 `;
 
 const LeftTopContainer = styled('div')`
   display: flex;
   width: 100%;
-  height: 50%;
+  height: calc(50% - 1rem);
   column-gap: 2rem;
 `;
 
 const LeftBottomContainer = styled('div')`
   display: flex;
   width: 100%;
-  height: 50%;
+  height: calc(50% - 1rem);
   column-gap: 2rem;
 `;
 

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -39,14 +39,15 @@ const LeftContainer = styled('div')`
   flex-direction: column;
   position: relative;
   width: 60%;
-  height: 100%;
+  height: 50%;
+  row-gap: 1rem;
 `;
 
 const LeftTopContainer = styled('div')`
   display: flex;
   width: 100%;
-  height: 50%;
-  padding-bottom: 16px;
+  height: 100%;
+  column-gap: 1rem;
 `;
 
 const LeftBottomContainer = styled('div')`
@@ -58,6 +59,7 @@ const LeftBottomContainer = styled('div')`
 const RightContainer = styled('div')`
   width: 40%;
   height: 100%;
+  column-gap: 1rem;
 `;
 
 export default Main;

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -32,6 +32,7 @@ const MainContainer = styled('div')`
   width: 100%;
   min-width: 1280px;
   padding: 32px;
+  background-color: #eee;
 `;
 
 const LeftContainer = styled('div')`
@@ -39,27 +40,28 @@ const LeftContainer = styled('div')`
   flex-direction: column;
   position: relative;
   width: 60%;
-  height: 50%;
-  row-gap: 1rem;
+  height: calc(100% - 2rem);
+  row-gap: 2rem;
 `;
 
 const LeftTopContainer = styled('div')`
   display: flex;
   width: 100%;
-  height: 100%;
-  column-gap: 1rem;
+  height: 50%;
+  column-gap: 2rem;
 `;
 
 const LeftBottomContainer = styled('div')`
   display: flex;
   width: 100%;
   height: 50%;
+  column-gap: 2rem;
 `;
 
 const RightContainer = styled('div')`
   width: 40%;
   height: 100%;
-  column-gap: 1rem;
+  padding-left: 2rem;
 `;
 
 export default Main;

--- a/frontend/admin/src/pages/Main/Main.tsx
+++ b/frontend/admin/src/pages/Main/Main.tsx
@@ -31,7 +31,7 @@ const MainContainer = styled('div')`
   display: flex;
   width: 100%;
   min-width: 1280px;
-  padding: 32px;
+  padding: 5rem;
   background-color: #eee;
 `;
 

--- a/frontend/admin/src/pages/Main/PromotionViewChart/PromotionViewChart.tsx
+++ b/frontend/admin/src/pages/Main/PromotionViewChart/PromotionViewChart.tsx
@@ -57,7 +57,7 @@ const PromotionViewChart = () => {
 
   return (
     <PieChartContainer>
-      <PieChartTitle color={theme.greenColor}>프로모션 조회수</PieChartTitle>
+      <PieChartTitle color={theme.black5}>프로모션 조회수</PieChartTitle>
       <ResponsiveContainer width='100%' height='100%'>
         <BarChart width={20} height={30} data={chartData}>
           <Bar dataKey='value' cursor='pointer' label={(entry) => entry.name}>
@@ -77,8 +77,8 @@ const PieChartContainer = styled.div`
   padding: 16px;
   width: 50%;
   height: 20rem;
-  background-color: whitesmoke;
-  border-radius: 16px;
+  background-color: #fff;
+  border-radius: 6px;
   font-size: 12px;
 `;
 
@@ -91,7 +91,7 @@ const PieChartTitle = styled.span<{ color: string }>`
 
 const CustomTooltipContainer = styled('div')`
   border-radius: 4px;
-  background-color: #eee;
+  background-color: #fff;
   color: #333;
   opacity: 0.95;
 `;

--- a/frontend/admin/src/pages/Main/PromotionViewChart/PromotionViewChart.tsx
+++ b/frontend/admin/src/pages/Main/PromotionViewChart/PromotionViewChart.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  Label,
+  YAxis,
+  LabelList,
+  TooltipProps,
+} from 'recharts';
+import styled from 'styled-components';
+import { theme } from '@src/theme/theme';
+import { PieChartData } from '@src/types/Chart';
+import PromotionAPI from '@src/apis/promotionAPI';
+import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+
+const PromotionViewChart = () => {
+  const [chartData, setChartData] = useState<PieChartData>([]);
+  const COLORS = [
+    theme.ChartColorRed,
+    theme.ChartColorBlue,
+    theme.ChartColorGreen,
+    theme.ChartColorPurple,
+    theme.ChartColorOrange,
+  ];
+
+  useEffect(() => {
+    async function fetchChartData() {
+      try {
+        const { result } = await PromotionAPI.getPromotions();
+        setChartData(
+          result.map(({ title, view }) => ({
+            name: title,
+            value: view,
+          }))
+        );
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchChartData();
+  }, []);
+
+  const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+    const payloadItem = payload?.[0]?.payload;
+    if (!active || !payloadItem) return null;
+    return (
+      <CustomTooltipContainer>
+        <CustomTooltipLabel>{`상품명 : ${payloadItem.name}`}</CustomTooltipLabel>
+        <CustomTooltipLabel>{`조회수 : ${payloadItem.value}`}</CustomTooltipLabel>
+      </CustomTooltipContainer>
+    );
+  };
+
+  return (
+    <PieChartContainer>
+      <PieChartTitle color={theme.greenColor}>프로모션 조회수</PieChartTitle>
+      <ResponsiveContainer width='100%' height='100%'>
+        <BarChart width={20} height={30} data={chartData}>
+          <Bar dataKey='value' cursor='pointer' label={(entry) => entry.name}>
+            {chartData.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+            <LabelList dataKey='name' position='top' />
+          </Bar>
+          <Tooltip cursor={false} content={<CustomTooltip />} />
+        </BarChart>
+      </ResponsiveContainer>
+    </PieChartContainer>
+  );
+};
+
+const PieChartContainer = styled.div`
+  padding: 16px;
+  width: 50%;
+  height: 20rem;
+  background-color: whitesmoke;
+  border-radius: 16px;
+  font-size: 12px;
+`;
+
+const PieChartTitle = styled.span<{ color: string }>`
+  position: absolute;
+  color: ${(props) => props.color};
+  font-weight: 700;
+  font-size: 17px;
+`;
+
+const CustomTooltipContainer = styled('div')`
+  border-radius: 4px;
+  background-color: #eee;
+  color: #333;
+  opacity: 0.95;
+`;
+
+const CustomTooltipLabel = styled('p')`
+  padding: 8px;
+  font-size: 12px;
+`;
+
+export default PromotionViewChart;

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
@@ -9,15 +9,16 @@ interface Props {
 }
 
 const TopSellingCategory: React.FC<Props> = ({ category, rank }) => {
-  const BGCOLOR = [theme.GOLD, theme.SILVER, theme.BRONZE, theme.LIGHTGRAY, theme.LIGHTGRAY];
+  const BGCOLOR = [theme.GOLD, theme.SILVER, theme.BRONZE, 'transparent', 'transparent'];
   return (
     <TopSellingCategoryContainer>
       <TopSellingInfoContainer>
         <TopSellingRank bgcolor={BGCOLOR[rank - 1]}>{rank}</TopSellingRank>
         <TopSellingCategoryTitle>{category.name}</TopSellingCategoryTitle>
       </TopSellingInfoContainer>
-      <TopSellingCategoryCountContainer color={theme.greenColor}>
-        <TopSellingCategoryCount>{convertCountOfSell(category.total)}</TopSellingCategoryCount>
+      <TopSellingCategoryCountContainer>
+        <TopSellingCategoryCount color={theme.greenColor}>{convertCountOfSell(category.total)}</TopSellingCategoryCount>
+        개
       </TopSellingCategoryCountContainer>
     </TopSellingCategoryContainer>
   );
@@ -31,30 +32,36 @@ const TopSellingCategoryContainer = styled.div`
 
 const TopSellingInfoContainer = styled.div`
   display: flex;
-  font-size: 1.1em;
-`;
-
-const TopSellingRank = styled.div<{ bgcolor: string }>`
-  margin-right: 24px;
-  background-color: ${(props) => props.bgcolor};
-  color: #fff;
-  width: 2em;
-  border-radius: 50%;
-  text-align: center;
-  line-height: 2em;
-`;
-const TopSellingCategoryTitle = styled.p`
-  display: flex;
+  font-size: 14px;
+  grid-gap: 1.5rem;
   align-items: center;
 `;
 
-const TopSellingCategoryCountContainer = styled.div<{ color: string }>`
-  padding: 0.5em;
-  background-color: ${(props) => props.color};
-  border-radius: 12px;
-`;
-const TopSellingCategoryCount = styled.span`
+const TopSellingRank = styled.div<{ bgcolor: string }>`
+  background-color: ${(props) => props.bgcolor};
   color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.6em;
+  height: 1.6em;
+  font-size: 11px;
+  border-radius: 50%;
+`;
+const TopSellingCategoryTitle = styled.p`
+  font-weight: 600;
+  color: #555;
+  font-size: 14px;
+`;
+
+const TopSellingCategoryCountContainer = styled.div`
+  font-size: 12px;
+`;
+const TopSellingCategoryCount = styled.span<{ color: string }>`
+  font-weight: 600;
+  font-size: 16px;
+  padding-right: 4px;
+  color: ${(props) => props.color};
 `;
 
 export default TopSellingCategory;

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategory/TopSellingCategory.tsx
@@ -33,7 +33,7 @@ const TopSellingCategoryContainer = styled.div`
 const TopSellingInfoContainer = styled.div`
   display: flex;
   font-size: 14px;
-  grid-gap: 1.5rem;
+  column-gap: 1.5rem;
   align-items: center;
 `;
 

--- a/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingCategoryList/TopSellingCategoryList.tsx
@@ -18,8 +18,8 @@ const TopSellingCategoryList = () => {
   return (
     <TopSellingContainer>
       <TopSellingTitleContainer>
-        <TopSellingTitle color={theme.greenColor}>Top Selling Categories</TopSellingTitle>
-        <TopSellingTitle color={theme.greenColor}>판매량</TopSellingTitle>
+        <TopSellingTitle color={theme.black5}>Top Selling Categories</TopSellingTitle>
+        <TopSellingTitle color={theme.black5}>판매량</TopSellingTitle>
       </TopSellingTitleContainer>
       <CategoriesContainer>
         {categories.map((category, i) => (
@@ -37,8 +37,8 @@ const TopSellingContainer = styled('div')`
   width: 50%;
   height: 100%;
   padding: 16px;
-  background-color: whitesmoke;
-  border-radius: 16px;
+  background-color: #fff;
+  border-radius: 6px;
 `;
 
 const TopSellingTitleContainer = styled('div')`
@@ -49,7 +49,7 @@ const TopSellingTitleContainer = styled('div')`
 const TopSellingTitle = styled('span')<{ color: string }>`
   color: ${(props) => props.color};
   height: 1.5em;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 16px;
 `;
 

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -1,3 +1,4 @@
+import originStyled from 'styled-components';
 import { styled } from '@src/lib/CustomStyledComponent';
 import { theme } from '@src/theme/theme';
 import convertCountOfSell from '@src/utils/convertCountOfSell';
@@ -17,33 +18,46 @@ const TopSellingGoods: React.FC<Props> = ({ item, rank }) => {
     <TopSellingGoodsContainer>
       <TopSellingGoodsImage src={item.thumbnailUrl} />
       <TopSellingGoodsTitle>{item.title}</TopSellingGoodsTitle>
-      <SellingGoodsCountContainer bgcolor={theme.greenColor}>
-        <TopSellingGoodsCount> {convertCountOfSell(item.countOfSell)}</TopSellingGoodsCount>
+      <SellingGoodsCountContainer>
+        <TopSellingGoodsCount color={theme.greenColor}> {convertCountOfSell(item.countOfSell)}</TopSellingGoodsCount>개
       </SellingGoodsCountContainer>
       <TopSellingRank bgcolor={theme.greenColor}>{rank + 1}</TopSellingRank>
     </TopSellingGoodsContainer>
   );
 };
 
-const TopSellingGoodsContainer = styled('div')`
+const TopSellingGoodsContainer = originStyled.div`
   position: relative;
   display: flex;
   align-items: center;
-  height: 15%;
   width: 100%;
-  margin-bottom: 16px;
+  justify-content: space-between;
+  cursor:pointer;
+  &:after {
+    transition: transform 0.15s linear;
+    position: absolute;
+    content: '';
+    width: 100%;
+    height: 1px;
+    bottom: 0;
+    left: 0;
+    border-bottom: 1px solid ${theme.black6};
+    transform: scale(0);
+  }
+  &:hover:after {
+    transform: scale(1);
+  }
 `;
 const TopSellingGoodsImage = styled('img')`
-  width: 64px;
-  height: 64px;
-  margin-right: 16px;
+  width: 40px;
+  height: 40px;
+  max-height: 100%;
   object-fit: cover;
   border-radius: 2px;
 `;
 
 const TopSellingGoodsTitle = styled('p')`
-  width: 60%;
-
+  width: 70%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
@@ -53,20 +67,21 @@ const TopSellingGoodsTitle = styled('p')`
   font-size: 14px;
 `;
 
-const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`
-  padding: 0.5em;
-  background-color: ${(props) => props.bgcolor};
-  border-radius: 12px;
+const SellingGoodsCountContainer = styled('div')`
+  font-size: 12px;
 `;
 
-const TopSellingGoodsCount = styled('span')`
-  color: #fff;
+const TopSellingGoodsCount = styled('span')<{ color: string }>`
+  font-weight: 600;
+  font-size: 16px;
+  padding-right: 4px;
+  color: ${(props) => props.color};
 `;
 
 const TopSellingRank = styled('div')<{ bgcolor: string }>`
   position: absolute;
-  top: -5px;
-  left: -5px;
+  top: 0px;
+  left: -10px;
   background-color: ${(props) => props.bgcolor};
   color: #fff;
   display: flex;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -27,27 +27,12 @@ const TopSellingGoods: React.FC<Props> = ({ item, rank }) => {
   );
 };
 
-const TopSellingGoodsContainer = originStyled.div`
+const TopSellingGoodsContainer = styled('div')`
   position: relative;
   display: flex;
   align-items: center;
   width: 100%;
   justify-content: space-between;
-  cursor:pointer;
-  &:after {
-    transition: transform 0.15s linear;
-    position: absolute;
-    content: '';
-    width: 100%;
-    height: 1px;
-    bottom: 0;
-    left: 0;
-    border-bottom: 1px solid ${theme.black6};
-    transform: scale(0);
-  }
-  &:hover:after {
-    transform: scale(1);
-  }
 `;
 const TopSellingGoodsImage = styled('img')`
   width: 40px;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -34,20 +34,23 @@ const TopSellingGoodsContainer = styled('div')`
   margin-bottom: 16px;
 `;
 const TopSellingGoodsImage = styled('img')`
-  width: 25%;
-  height: 100%;
+  width: 64px;
+  height: 64px;
   margin-right: 16px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: 2px;
 `;
 
 const TopSellingGoodsTitle = styled('p')`
   width: 60%;
-  margin-right: 16px;
+
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   text-align: start;
+  color: #555;
+  font-weight: 600;
+  font-size: 14px;
 `;
 
 const SellingGoodsCountContainer = styled('div')<{ bgcolor: string }>`
@@ -64,11 +67,15 @@ const TopSellingRank = styled('div')<{ bgcolor: string }>`
   position: absolute;
   top: -5px;
   left: -5px;
-  text-align: center;
   background-color: ${(props) => props.bgcolor};
   color: #fff;
-  width: 1.1em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.6em;
+  height: 1.6em;
   border-radius: 50%;
+  font-size: 11px;
 `;
 
 export default TopSellingGoods;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoods/TopSellingGoods.tsx
@@ -14,6 +14,7 @@ interface Props {
 }
 
 const TopSellingGoods: React.FC<Props> = ({ item, rank }) => {
+  const BGCOLOR = [theme.GOLD, theme.SILVER, theme.BRONZE, 'transparent', 'transparent'];
   return (
     <TopSellingGoodsContainer>
       <TopSellingGoodsImage src={item.thumbnailUrl} />
@@ -21,7 +22,7 @@ const TopSellingGoods: React.FC<Props> = ({ item, rank }) => {
       <SellingGoodsCountContainer>
         <TopSellingGoodsCount color={theme.greenColor}> {convertCountOfSell(item.countOfSell)}</TopSellingGoodsCount>개
       </SellingGoodsCountContainer>
-      <TopSellingRank bgcolor={theme.greenColor}>{rank + 1}</TopSellingRank>
+      <TopSellingRank bgcolor={BGCOLOR[rank - 1]}>{rank}</TopSellingRank>
     </TopSellingGoodsContainer>
   );
 };
@@ -78,7 +79,7 @@ const TopSellingGoodsCount = styled('span')<{ color: string }>`
   color: ${(props) => props.color};
 `;
 
-const TopSellingRank = styled('div')<{ bgcolor: string }>`
+const TopSellingRank = originStyled.div<{ bgcolor: string }>`
   position: absolute;
   top: 0px;
   left: -10px;

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -24,7 +24,7 @@ const TopSellingGoodsList = () => {
       </TopSellingTitleContainer>
       <GoodsListContainer>
         {goodsList.map((item, i) => (
-          <TopSellingGoods key={i} item={item} rank={i} />
+          <TopSellingGoods key={i} item={item} rank={i + 1} />
         ))}
       </GoodsListContainer>
     </TopSellingContainer>

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -19,8 +19,8 @@ const TopSellingGoodsList = () => {
   return (
     <TopSellingContainer>
       <TopSellingTitleContainer>
-        <TopSellingTitle bgcolor={theme.greenColor}>Top Selling Goods</TopSellingTitle>
-        <TopSellingTitle bgcolor={theme.greenColor}>판매량</TopSellingTitle>
+        <TopSellingTitle bgcolor={theme.black5}>Top Selling Goods</TopSellingTitle>
+        <TopSellingTitle bgcolor={theme.black5}>판매량</TopSellingTitle>
       </TopSellingTitleContainer>
       <GoodsListContainer>
         {goodsList.map((item, i) => (
@@ -38,8 +38,8 @@ const TopSellingContainer = styled('div')`
   width: 50%;
   height: 100%;
   padding: 16px;
-  background-color: whitesmoke;
-  border-radius: 16px;
+  background-color: #fff;
+  border-radius: 6px;
 `;
 const TopSellingTitleContainer = styled('div')`
   display: flex;
@@ -55,7 +55,7 @@ const GoodsListContainer = styled('div')`
 const TopSellingTitle = styled('span')<{ bgcolor: string }>`
   color: ${(props) => props.bgcolor};
   height: 1.5em;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 16px;
 `;
 

--- a/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
+++ b/frontend/admin/src/pages/Main/TopSellingGoodsList/TopSellingGoodsList.tsx
@@ -47,9 +47,10 @@ const TopSellingTitleContainer = styled('div')`
 `;
 const GoodsListContainer = styled('div')`
   position: relative;
-  display: flex;
+  display: grid;
   flex-direction: column;
   height: 100%;
+  row-gap: 1rem;
 `;
 
 const TopSellingTitle = styled('span')<{ bgcolor: string }>`

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
@@ -1,6 +1,7 @@
 import PromotionAPI from '@src/apis/promotionAPI';
 import { styled } from '@src/lib/CustomStyledComponent';
 import PromotionList from '@src/pages/PromotionAdmin/PromotionList/PromotionList';
+import PromotionViewChart from '@src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart';
 import PromotionUploadModal from '@src/portal/PromotionUploadModal/PromotionUploadModal';
 import { theme } from '@src/theme/theme';
 import { Promotion } from '@src/types/Promotion';
@@ -19,7 +20,7 @@ const PromotionAdmin = () => {
     }
   }, [setPromotions]);
 
-  const handleOpenModal = useCallback(() => {
+  const onOpenModal = useCallback(() => {
     setOpenPromotionModal(true);
   }, [setOpenPromotionModal]);
 
@@ -37,10 +38,11 @@ const PromotionAdmin = () => {
   }, []);
   return (
     <PromotionAdminContainer>
-      <PromotionCounterContainer>
-        <PromotionSpan color={theme.greenColor}>{`등록된 프로모션 ${promotions.length}건`}</PromotionSpan>
-      </PromotionCounterContainer>
-      <PromotionList promotions={promotions} onDeletePromotion={handleDeletePromotion} onOpenModal={handleOpenModal} />
+      <PromotionChartAndButtonContainer>
+        <PromotionViewChart />
+        <PromotionAddButton onClick={onOpenModal}>+</PromotionAddButton>
+      </PromotionChartAndButtonContainer>
+      <PromotionList promotions={promotions} onDeletePromotion={handleDeletePromotion} />
       {openPromotionModal && <PromotionUploadModal updatePromotions={fetchingPromotions} onClose={handleCloseModal} />}
     </PromotionAdminContainer>
   );
@@ -52,16 +54,23 @@ const PromotionAdminContainer = styled('div')`
   min-width: 1280px;
 `;
 
-const PromotionCounterContainer = styled('div')`
-  margin-left: 5%;
-  margin-top: 3%;
-  margin-bottom: 2%;
+const PromotionChartAndButtonContainer = styled('div')`
+  position: relative;
+  padding: 16px;
+  width: 100%;
+  height: 300px;
+  display: flex;
+  align-items: center;
 `;
-const PromotionSpan = styled('span')<{ color: string }>`
-  color: ${(props) => props.color};
-  font-weight: 700;
-  font-size: 1.2em;
-  margin-right: 12px;
+const PromotionAddButton = styled('button')`
+  position: relative;
+  font-size: 2em;
+  width: 50%;
+  height: 250px;
+  border-radius: 20px;
+  cursor: pointer;
+  border: none;
+  color: gray;
 `;
 
 export default PromotionAdmin;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionAdmin.tsx
@@ -3,7 +3,6 @@ import { styled } from '@src/lib/CustomStyledComponent';
 import PromotionList from '@src/pages/PromotionAdmin/PromotionList/PromotionList';
 import PromotionViewChart from '@src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart';
 import PromotionUploadModal from '@src/portal/PromotionUploadModal/PromotionUploadModal';
-import { theme } from '@src/theme/theme';
 import { Promotion } from '@src/types/Promotion';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -13,7 +12,7 @@ const PromotionAdmin = () => {
 
   const fetchingPromotions = useCallback(async () => {
     try {
-      const { result } = await PromotionAPI.getPromotions();
+      const { result } = await PromotionAPI.getPromotionsForAdmin();
       setPromotions(result);
     } catch (err) {
       console.error(err);
@@ -38,8 +37,12 @@ const PromotionAdmin = () => {
   }, []);
   return (
     <PromotionAdminContainer>
+      <GoodsAdminHeader>
+        <Title>프로모션 관리</Title>
+        <PromotionSpan>{`총 프로모션 ${promotions.length}건`}</PromotionSpan>
+      </GoodsAdminHeader>
       <PromotionChartAndButtonContainer>
-        <PromotionViewChart />
+        <PromotionViewChart promotions={promotions} />
         <PromotionAddButton onClick={onOpenModal}>+</PromotionAddButton>
       </PromotionChartAndButtonContainer>
       <PromotionList promotions={promotions} onDeletePromotion={handleDeletePromotion} />
@@ -49,9 +52,28 @@ const PromotionAdmin = () => {
 };
 
 const PromotionAdminContainer = styled('div')`
-  position: relative;
   width: 100%;
+  position: relative;
+  margin: 5rem;
+  margin-bottom: 0;
+  overflow-y: auto;
   min-width: 1280px;
+`;
+
+const GoodsAdminHeader = styled('div')`
+  display: flex;
+  column-gap: 1rem;
+  margin-bottom: 20px;
+  align-items: flex-end;
+`;
+
+const Title = styled('h2')`
+  font-size: 24px;
+  font-weight: 600;
+`;
+
+const PromotionSpan = styled('span')`
+  font-size: 16px;
 `;
 
 const PromotionChartAndButtonContainer = styled('div')`
@@ -64,9 +86,10 @@ const PromotionChartAndButtonContainer = styled('div')`
 `;
 const PromotionAddButton = styled('button')`
   position: relative;
-  font-size: 2em;
+  font-size: 3rem;
   width: 50%;
   height: 250px;
+  margin: 1rem;
   border-radius: 20px;
   cursor: pointer;
   border: none;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
@@ -53,14 +53,14 @@ const PromotionItem: React.FC<Props> = ({ promotion, onDeletePromotion }) => {
 const PromotionContainer = styled('div')`
   position: relative;
   width: 50%;
-  height: 300px;
+  height: 280px;
   padding: 1rem;
   margin-bottom: 1rem;
 `;
 
 const PromotionImage = styled('img')`
   width: 100%;
-  height: 300px;
+  height: 100%;
   border-radius: 10px;
 `;
 

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem.tsx
@@ -52,26 +52,24 @@ const PromotionItem: React.FC<Props> = ({ promotion, onDeletePromotion }) => {
 
 const PromotionContainer = styled('div')`
   position: relative;
-  padding-top: 5px;
-  padding-bottom: 5px;
-  width: 100%;
-  height: 350px;
-  min-width: 440px;
-  min-height: 320px;
+  width: 50%;
+  height: 300px;
+  padding: 1rem;
+  margin-bottom: 1rem;
 `;
 
 const PromotionImage = styled('img')`
   width: 100%;
   height: 300px;
-  border-radius: 20px;
+  border-radius: 10px;
 `;
 
 const PromotionDeleteButton = styled('button')<{ bgcolor: string }>`
   position: absolute;
   display: flex;
   align-items: center;
-  top: 15px;
-  right: 15px;
+  top: 10px;
+  right: 10px;
   font-size: 1.5em;
   width: 1.5em;
   height: 1.5em;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
@@ -1,59 +1,48 @@
 import { styled } from '@src/lib/CustomStyledComponent';
 import PromotionItem from '@src/pages/PromotionAdmin/PromotionList/PromotionItem/PromotionItem';
+import { theme } from '@src/theme/theme';
 import { Promotion } from '@src/types/Promotion';
 import React from 'react';
 
 interface Props {
   promotions: Promotion[];
   onDeletePromotion: (promotionId: number) => Promise<void>;
-  onOpenModal: () => void;
 }
 
-const PromotionList: React.FC<Props> = ({ promotions, onDeletePromotion, onOpenModal }) => {
+const PromotionList: React.FC<Props> = ({ promotions, onDeletePromotion }) => {
   return (
-    <PromotionListContainer>
-      <PromotionAddButtonContainer>
-        <PromotionAddButton onClick={onOpenModal}>+</PromotionAddButton>
-      </PromotionAddButtonContainer>
-      {promotions.map((promotion) => (
-        <PromotionItem key={promotion.id} onDeletePromotion={onDeletePromotion} promotion={promotion} />
-      ))}
-    </PromotionListContainer>
+    <>
+      {/* <PromotionSpan color={theme.greenColor}>{`등록된 프로모션 ${promotions.length}건`}</PromotionSpan> */}
+      <PromotionListContainer>
+        {promotions.map((promotion) => (
+          <PromotionItem key={promotion.id} onDeletePromotion={onDeletePromotion} promotion={promotion} />
+        ))}
+      </PromotionListContainer>
+    </>
   );
 };
+
+const PromotionCounterContainer = styled('div')`
+  margin-left: 5%;
+  margin-top: 3%;
+  margin-bottom: 2%;
+`;
+
+const PromotionSpan = styled('span')<{ color: string }>`
+  color: ${(props) => props.color};
+  font-weight: 700;
+  font-size: 1.2em;
+  margin-right: 12px;
+`;
 
 const PromotionListContainer = styled('ul')`
   position: relative;
   display: flex;
-  width: 90%;
-  min-width: 972px;
-  height: 80%;
+  width: 100%;
   margin: auto;
   flex-wrap: wrap;
   overflow: auto;
-  padding: 40px 40px 0 40px;
-  border: 1px solid lightgray;
-  border-radius: 16px;
-`;
-
-const PromotionAddButtonContainer = styled('div')`
-  position: relative;
-  padding: 10px;
-  width: 100%;
-  height: 400px;
-  min-width: 440px;
-  min-height: 320px;
-`;
-
-const PromotionAddButton = styled('button')`
-  position: relative;
-  font-size: 2em;
-  width: 100%;
-  height: 250px;
-  border-radius: 20px;
-  cursor: pointer;
-  border: none;
-  color: gray;
+  padding: 16px;
 `;
 
 export default PromotionList;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionList/PromotionList.tsx
@@ -12,7 +12,6 @@ interface Props {
 const PromotionList: React.FC<Props> = ({ promotions, onDeletePromotion }) => {
   return (
     <>
-      {/* <PromotionSpan color={theme.greenColor}>{`등록된 프로모션 ${promotions.length}건`}</PromotionSpan> */}
       <PromotionListContainer>
         {promotions.map((promotion) => (
           <PromotionItem key={promotion.id} onDeletePromotion={onDeletePromotion} promotion={promotion} />
@@ -21,19 +20,6 @@ const PromotionList: React.FC<Props> = ({ promotions, onDeletePromotion }) => {
     </>
   );
 };
-
-const PromotionCounterContainer = styled('div')`
-  margin-left: 5%;
-  margin-top: 3%;
-  margin-bottom: 2%;
-`;
-
-const PromotionSpan = styled('span')<{ color: string }>`
-  color: ${(props) => props.color};
-  font-weight: 700;
-  font-size: 1.2em;
-  margin-right: 12px;
-`;
 
 const PromotionListContainer = styled('ul')`
   position: relative;

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
@@ -13,18 +13,19 @@ import {
 } from 'recharts';
 import styled from 'styled-components';
 import { theme } from '@src/theme/theme';
-import { PieChartData } from '@src/types/Chart';
+import { BarChartData } from '@src/types/Chart';
 import PromotionAPI from '@src/apis/promotionAPI';
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 
 const PromotionViewChart = () => {
-  const [chartData, setChartData] = useState<PieChartData>([]);
+  const [chartData, setChartData] = useState<BarChartData>([]);
   const COLORS = [
     theme.ChartColorRed,
     theme.ChartColorBlue,
     theme.ChartColorGreen,
     theme.ChartColorPurple,
     theme.ChartColorOrange,
+    theme.ChartColorYellow,
   ];
 
   useEffect(() => {
@@ -56,37 +57,39 @@ const PromotionViewChart = () => {
   };
 
   return (
-    <PieChartContainer>
-      <PieChartTitle color={theme.black5}>프로모션 조회수</PieChartTitle>
+    <BarChartContainer>
+      <BarChartTitle color={theme.black5}>프로모션 조회수</BarChartTitle>
       <ResponsiveContainer width='100%' height='100%'>
         <BarChart width={20} height={30} data={chartData}>
-          <Bar dataKey='value' cursor='pointer' label={(entry) => entry.name}>
+          <Bar maxBarSize={30} dataKey='value' cursor='pointer' label={(entry) => entry.name}>
             {chartData.map((_, index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
             ))}
-            <LabelList dataKey='name' position='top' />
           </Bar>
+          <XAxis dataKey={'name'} />
+          <YAxis dataKey={'value'} />
           <Tooltip cursor={false} content={<CustomTooltip />} />
         </BarChart>
       </ResponsiveContainer>
-    </PieChartContainer>
+    </BarChartContainer>
   );
 };
 
-const PieChartContainer = styled.div`
+const BarChartContainer = styled.div`
   padding: 16px;
   width: 50%;
-  height: 20rem;
+  height: 100%;
+  position: relative;
   background-color: #fff;
   border-radius: 6px;
   font-size: 12px;
 `;
 
-const PieChartTitle = styled.span<{ color: string }>`
-  position: absolute;
+const BarChartTitle = styled.p<{ color: string }>`
   color: ${(props) => props.color};
   font-weight: 700;
   font-size: 17px;
+  margin-bottom: 1rem;
 `;
 
 const CustomTooltipContainer = styled('div')`

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
@@ -1,23 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Tooltip,
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  Cell,
-  XAxis,
-  Label,
-  YAxis,
-  LabelList,
-  TooltipProps,
-} from 'recharts';
+import { Tooltip, ResponsiveContainer, BarChart, Bar, Cell, XAxis, YAxis, TooltipProps } from 'recharts';
 import styled from 'styled-components';
 import { theme } from '@src/theme/theme';
 import { BarChartData } from '@src/types/Chart';
-import PromotionAPI from '@src/apis/promotionAPI';
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import { Promotion } from '@src/types/Promotion';
 
-const PromotionViewChart = () => {
+interface Props {
+  promotions: Promotion[];
+}
+
+const PromotionViewChart: React.FC<Props> = ({ promotions }) => {
   const [chartData, setChartData] = useState<BarChartData>([]);
   const COLORS = [
     theme.ChartColorRed,
@@ -29,21 +22,13 @@ const PromotionViewChart = () => {
   ];
 
   useEffect(() => {
-    async function fetchChartData() {
-      try {
-        const { result } = await PromotionAPI.getPromotionChartData();
-        setChartData(
-          result.map(({ title, view }) => ({
-            name: title,
-            value: view,
-          }))
-        );
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    fetchChartData();
-  }, []);
+    setChartData(
+      promotions.map(({ title, view }) => ({
+        name: title,
+        value: view,
+      }))
+    );
+  }, [promotions]);
 
   const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
     const payloadItem = payload?.[0]?.payload;
@@ -58,7 +43,7 @@ const PromotionViewChart = () => {
 
   return (
     <BarChartContainer>
-      <BarChartTitle color={theme.black5}>프로모션 조회수</BarChartTitle>
+      <BarChartTitle color={theme.black5}>프로모션 조회수 차트</BarChartTitle>
       <ResponsiveContainer width='100%' height='100%'>
         <BarChart width={20} height={30} data={chartData}>
           <Bar maxBarSize={30} dataKey='value' cursor='pointer' label={(entry) => entry.name}>

--- a/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
+++ b/frontend/admin/src/pages/PromotionAdmin/PromotionViewChart/PromotionViewChart.tsx
@@ -31,7 +31,7 @@ const PromotionViewChart = () => {
   useEffect(() => {
     async function fetchChartData() {
       try {
-        const { result } = await PromotionAPI.getPromotions();
+        const { result } = await PromotionAPI.getPromotionChartData();
         setChartData(
           result.map(({ title, view }) => ({
             name: title,

--- a/frontend/admin/src/portal/GoodsUploadModal/GoodsUploadModal.tsx
+++ b/frontend/admin/src/portal/GoodsUploadModal/GoodsUploadModal.tsx
@@ -44,7 +44,9 @@ const GoodsUploadModal: React.FC<Props> = ({ onClose, goods }) => {
     formData.append('state', convertGoodsState(productState));
     if (oldImages.length > 0) {
       formData.append('oldImages', oldImages.map((image) => image.id).join());
+      formData.append('thumbnailUrl', oldImages[0].url);
     }
+
     try {
       const { result } = goods ? await GoodsAPI.updateGoods(formData, goods.id) : await GoodsAPI.createGoods(formData);
       if (result) onClose();

--- a/frontend/admin/src/theme/theme.ts
+++ b/frontend/admin/src/theme/theme.ts
@@ -28,6 +28,10 @@ export const theme = {
   LIGHTGRAY: 'rgba(211,211,211,0.7)',
 
   WHITE: '#fff',
+  grayE: '#eee',
+  grayD: '#ddd',
+  grayC: '#ccc',
+  grayB: '#bbb',
   black3: '#333333',
   black5: '#555555',
   black6: '#666666',

--- a/frontend/admin/src/theme/theme.ts
+++ b/frontend/admin/src/theme/theme.ts
@@ -28,4 +28,7 @@ export const theme = {
   LIGHTGRAY: 'rgba(211,211,211,0.7)',
 
   WHITE: '#fff',
+  black3: '#333333',
+  black5: '#555555',
+  black6: '#666666',
 };

--- a/frontend/admin/src/theme/theme.ts
+++ b/frontend/admin/src/theme/theme.ts
@@ -15,16 +15,16 @@ export const theme = {
   offWhite: '#FCFCFC',
   line: '#CCD3D3',
 
-  ChartColorRed: 'rgba(255, 99, 132, 0.6)',
-  ChartColorBlue: 'rgba(54, 162, 235, 0.6)',
-  ChartColorYellow: 'rgba(255, 206, 86, 0.6)',
-  ChartColorGreen: 'rgba(75, 192, 192, 0.6)',
-  ChartColorPurple: 'rgba(153, 102, 255, 0.6)',
-  ChartColorOrange: 'rgba(255, 159, 64, 0.6)',
+  ChartColorRed: 'rgba(255, 99, 132, 0.9)',
+  ChartColorBlue: 'rgba(54, 162, 235, 0.9)',
+  ChartColorYellow: 'rgba(255, 206, 86, 0.9)',
+  ChartColorGreen: 'rgba(75, 192, 192, 0.9)',
+  ChartColorPurple: 'rgba(153, 102, 255, 0.9)',
+  ChartColorOrange: 'rgba(255, 159, 64, 0.9)',
 
   GOLD: '#ffe34d',
   BRONZE: '#cd7f32',
-  SILVER: 'rgba(192,192,192,0.6)',
+  SILVER: 'rgba(192,192,192,0.9)',
   LIGHTGRAY: 'rgba(211,211,211,0.7)',
 
   WHITE: '#fff',

--- a/frontend/admin/src/types/Chart.ts
+++ b/frontend/admin/src/types/Chart.ts
@@ -1,5 +1,10 @@
-type PieData = {
+type Data = {
   name: string;
   value: number;
 };
+
+type PieData = Data;
+type BarData = Data;
+
 export type PieChartData = PieData[];
+export type BarChartData = BarData[];

--- a/frontend/admin/src/types/Goods.ts
+++ b/frontend/admin/src/types/Goods.ts
@@ -33,9 +33,9 @@ export interface GoodsPaginationResult {
 export interface GetGoodsByOptionProps {
   page: number;
   limit: number;
+  flag: string;
+  sort: 'ASC' | 'DESC';
   keyword?: string;
-  order?: string;
-  sort?: 'ASC' | 'DESC';
 }
 
 export interface Goods {

--- a/frontend/admin/src/types/Goods.ts
+++ b/frontend/admin/src/types/Goods.ts
@@ -33,8 +33,8 @@ export interface GoodsPaginationResult {
 export interface GetGoodsByOptionProps {
   page: number;
   limit: number;
-  flag: string;
-  sort: 'ASC' | 'DESC';
+  sort?: 'ASC' | 'DESC';
+  flag?: string;
   keyword?: string;
 }
 

--- a/frontend/admin/src/types/Promotion.ts
+++ b/frontend/admin/src/types/Promotion.ts
@@ -1,7 +1,10 @@
 export interface Promotion {
   id: number;
-  view: number;
   imgUrl: string;
-  title: string;
-  goodsId?: number;
 }
+
+export type PromotionChartData = Promotion & {
+  view: number;
+  title: string;
+  goodsId: number;
+};

--- a/frontend/admin/src/types/Promotion.ts
+++ b/frontend/admin/src/types/Promotion.ts
@@ -1,4 +1,7 @@
 export interface Promotion {
   id: number;
+  view: number;
   imgUrl: string;
+  title: string;
+  goodsId?: number;
 }

--- a/frontend/admin/src/types/Promotion.ts
+++ b/frontend/admin/src/types/Promotion.ts
@@ -1,10 +1,7 @@
 export interface Promotion {
   id: number;
   imgUrl: string;
-}
-
-export type PromotionChartData = Promotion & {
   view: number;
   title: string;
   goodsId: number;
-};
+}

--- a/frontend/client/src/apis/goodsAPI.ts
+++ b/frontend/client/src/apis/goodsAPI.ts
@@ -5,20 +5,24 @@ export interface GetGoodsByCategoryProps {
   categoryName: string;
   page: number;
   flag: string;
+  sort?: 'ASC' | 'DESC';
   limit?: number;
 }
 
 // TODO: 상품 수가 충분해지면 페이지당 상품 수 조정
 const DEFAULT_GOODS_LIMIT = 5;
 
+const DEFAULT_SORT = 'DESC';
+
 export const getGoodsByCategory = async ({
   categoryName,
   page,
   flag,
+  sort = DEFAULT_SORT,
   limit = DEFAULT_GOODS_LIMIT,
 }: GetGoodsByCategoryProps): Promise<APIResponse<GoodsPaginationResult>> => {
   const res = await checkedFetch(
-    `/api/goods/category?category=${categoryName}&page=${page}&flag=${flag}&limit=${limit}`,
+    `/api/goods/category?category=${categoryName}&flag=${flag}&limit=${limit}&sort=${sort}&page=${page}`,
     {
       method: 'GET',
       credentials: 'include',
@@ -31,14 +35,16 @@ export interface GetGoodsByKeywordProps {
   keyword: string;
   page: number;
   limit?: number;
+  sort?: 'ASC' | 'DESC';
 }
 
 export const getGoodsByKeyword = async ({
   keyword,
   page,
+  sort = DEFAULT_SORT,
   limit = DEFAULT_GOODS_LIMIT,
 }: GetGoodsByKeywordProps): Promise<APIResponse<GoodsPaginationResult>> => {
-  const res = await checkedFetch(`/api/goods/keyword?keyword=${keyword}&page=${page}&limit=${limit}`, {
+  const res = await checkedFetch(`/api/goods/keyword?keyword=${keyword}&limit=${limit}&sort=${sort}&page=${page}`, {
     method: 'GET',
     credentials: 'include',
   });
@@ -72,10 +78,13 @@ export const getGoodsStockCount = async (goodsId: number): Promise<APIResponse<n
 // 같은 카테고리인 상품을 4개까지 가져옴
 export const getRelationGoods = async (categoryName: string): Promise<APIResponse<GoodsPaginationResult>> => {
   const RELATION_LIMIT = 4;
-  const res = await checkedFetch(`/api/goods/category?category=${categoryName}&limit=${RELATION_LIMIT}&page=1`, {
-    method: 'GET',
-    credentials: 'include',
-  });
+  const res = await checkedFetch(
+    `/api/goods/category?category=${categoryName}&sort=${DEFAULT_SORT}&limit=${RELATION_LIMIT}&page=1`,
+    {
+      method: 'GET',
+      credentials: 'include',
+    }
+  );
   return await res.json();
 };
 

--- a/frontend/client/src/pages/CategoryGoods/CategoryGoodsList/CategoryGoodsList.tsx
+++ b/frontend/client/src/pages/CategoryGoods/CategoryGoodsList/CategoryGoodsList.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-
 import GoodsSection from '@src/components/GoodsSection/GoodsSection';
 import CategoryFlag from '@src/pages/CategoryGoods/CategoryGoodsList/CategoryFlag';
 import Paginator from '@src/components/Paginator/Paginator';
@@ -13,10 +12,10 @@ interface Props {
 }
 
 const GoodsFlag = {
-  best: 'best',
-  latest: 'latest',
-  low: 'low',
-  high: 'high',
+  best: 'sell',
+  latest: 'create',
+  low: 'low_price',
+  high: 'high_price',
 };
 
 const flags = [
@@ -29,6 +28,10 @@ const flags = [
 const LIMIT_COUNT_ITEMS_IN_PAGE = 8;
 const DEFAULT_START_PAGE = 1;
 
+const getOrderByOption = (flag: string) => (flag === 'low_price' ? 'ASC' : 'DESC');
+
+const convertAPIFlag = (flag: string) => (flag === 'low_price' || flag === 'high_price' ? 'price' : flag);
+
 const CategoryGoodsList: React.FC<Props> = ({ category }) => {
   const [goodsListMap, setGoodsListMap] = useState<GoodsPaginationResult | null>(null);
   const [searchQuery, setSearchQuery] = useScrollToTop<GetGoodsByCategoryProps>({
@@ -39,7 +42,12 @@ const CategoryGoodsList: React.FC<Props> = ({ category }) => {
 
   const fetchGoodsList = async () => {
     try {
-      const data = await getGoodsByCategory({ ...searchQuery, limit: LIMIT_COUNT_ITEMS_IN_PAGE });
+      const data = await getGoodsByCategory({
+        ...searchQuery,
+        limit: LIMIT_COUNT_ITEMS_IN_PAGE,
+        sort: getOrderByOption(searchQuery.flag),
+        flag: convertAPIFlag(searchQuery.flag),
+      });
       setGoodsListMap(data.result);
     } catch (e) {
       setGoodsListMap(null);


### PR DESCRIPTION
## :bookmark_tabs: 제목

관리자 페이지 상품 정렬 기능 추가 및 대시보드, 프로모션 관리 UI 수정

![관리자 페이지 상품 정렬 기능 추가 및 대시보드, 프로모션 관리 UI 수정](https://user-images.githubusercontent.com/45394360/130712153-e2bc32b8-59ce-4f45-89e3-17fd1b078f8a.gif)

![#199 버그 수정](https://user-images.githubusercontent.com/45394360/130712338-3b04275f-8185-4ead-90f1-ebbb12afabdb.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 개발 환경 실행 및 build, test가 정상적이었나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] (작업 내역 2)
- [x] 프로모션 차트 UI 
- [x] 대시보드 스타일 수정
- [x] 프로모션 스타일 수정
- [x] 상품 관리 상품 목록 정렬 기능  