### PR TITLE
[feature/197] Bug Category 조회 수 Goods가 부모 Category일 경우 예외 처리  

### DIFF
--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -90,17 +90,16 @@ async function getCategoryViews(): Promise<CategoryViewCountResponse> {
   const goods = await GoodsRepository.findAllWithCategory();
   // category parentId를 key로 조회 수 총합을 구합니다.
   goods.forEach((item) => {
-    if (categories[item.category.parent]) {
-      categories[item.category.parent] += item.view;
+    let parent;
+    if (!item.category.parent && item.category) parent = item.category.id;
+    else parent = item.category.parent;
+    if (categories[parent]) {
+      categories[parent] += item.view;
     } else {
-      categories[item.category.parent] = item.view;
+      categories[parent] = item.view;
     }
   });
-  await Promise.all(
-    Object.keys(categories)
-      .filter((key) => isNumber(key))
-      .map((key) => pushCategoryViewToList(Number(key), categories[key], result))
-  );
+  await Promise.all(Object.keys(categories).map((key) => pushCategoryViewToList(Number(key), categories[key], result)));
   return result;
 }
 


### PR DESCRIPTION
## :bookmark_tabs: 제목

Category 조회 수 Goods가 부모 Category일 경우 예외 처리 

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

-[X] 카테고리 조회 수 가공할 때 부모 Category로만 등록된 Goods의 경우 예외처리

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
