### PR TITLE
[feature/209] Toast 기본 노출 시간 감소, 최대 노출 개수 로직 추가

### DIFF
--- a/frontend/client/src/lib/ToastProvider/ToastProvider.tsx
+++ b/frontend/client/src/lib/ToastProvider/ToastProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useRef, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import Toast from './Toast/Toast';
 import ToastPortalWrapper from './ToastPortalWrapper/ToastPortalWrapper';
 
@@ -30,7 +30,8 @@ interface ToastState extends ToastData {
   onDisplayTimeEnd: () => void;
 }
 
-const DEFAULT_DISPLAY_TIME = 3000;
+const DEFAULT_DISPLAY_TIME = 2000;
+const DEFAULT_MAX_TOAST_COUNT = 1;
 
 const ToastProvider: React.FC = ({ children }) => {
   const [toasts, setToasts] = useState<ToastState[]>([]);
@@ -49,6 +50,14 @@ const ToastProvider: React.FC = ({ children }) => {
       return [...currentToasts, { ...newToast, id, onDisplayTimeEnd }];
     });
   };
+
+  useEffect(() => {
+    if (toasts.length > DEFAULT_MAX_TOAST_COUNT) {
+      setToasts((currentToasts) => {
+        return currentToasts.slice(toasts.length - DEFAULT_MAX_TOAST_COUNT);
+      });
+    }
+  }, [toasts]);
 
   return (
     <ToastContext.Provider value={{ pushToast }}>


### PR DESCRIPTION

https://user-images.githubusercontent.com/64543699/130775854-e2b03318-6a13-4aa7-b997-b73410f546bc.mov

## Toast 기본 노출 시간 감소 (3000ms -> 2000ms)

## 최대 노출 개수 로직 추가하였습니다. (기본값으로 1개 노출)