### PR TITLE
[feature/214] 관리자페이지의 파이차트에서 정확한 상품 수를 출력하도록 수정했습니다.

### DIFF
--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -19,8 +19,8 @@ async function getAllCategory(req: Request, res: Response) {
   });
 }
 
-async function getParentCategoryCount(req: Request, res: Response) {
-  const result = await CategoryService.getParentCategoryCount();
+async function getCategoryCounts(req: Request, res: Response) {
+  const result = await CategoryService.getCategoryCount();
   res.status(200).json({ result });
 }
 
@@ -37,7 +37,7 @@ async function getCategoryViews(req: Request, res: Response) {
 export default {
   createCategory,
   getAllCategory,
-  getParentCategoryCount,
+  getCategoryCounts,
   getTopSellingCategory,
   getCategoryViews,
 };

--- a/backend/src/controller/category.controller.ts
+++ b/backend/src/controller/category.controller.ts
@@ -19,8 +19,8 @@ async function getAllCategory(req: Request, res: Response) {
   });
 }
 
-async function getCategoryCounts(req: Request, res: Response) {
-  const result = await CategoryService.getCategoryCount();
+async function getCategoryGoodsCounts(req: Request, res: Response) {
+  const result = await CategoryService.getCategoryGoodsCount();
   res.status(200).json({ result });
 }
 
@@ -37,7 +37,7 @@ async function getCategoryViews(req: Request, res: Response) {
 export default {
   createCategory,
   getAllCategory,
-  getCategoryCounts,
+  getCategoryGoodsCounts,
   getTopSellingCategory,
   getCategoryViews,
 };

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -50,7 +50,7 @@ export default async function () {
 }
 
 async function populate() {
-  await createDefaultUser('아이유');
+  await createDefaultUser('배달의 민족');
   await createDefaultAddress();
   await createDefaultCategory();
   await createDefaultDeliveryInfo();
@@ -62,7 +62,11 @@ async function populate() {
 async function createDefaultUser(name: string) {
   const result = await UserRepository.findByGitHubId('1');
   if (!result) {
-    await UserRepository.create('1', name);
+    await UserRepository.create(
+      '1',
+      name,
+      'https://user-images.githubusercontent.com/20085849/130751828-440dcec8-5619-41f3-9b2d-e0c73056c375.png'
+    );
   }
 }
 

--- a/backend/src/entity/Category.ts
+++ b/backend/src/entity/Category.ts
@@ -1,4 +1,5 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Goods } from './Goods';
 
 @Entity()
 export class Category {
@@ -16,4 +17,7 @@ export class Category {
 
   @Column({ nullable: true })
   parent: number;
+
+  @OneToMany(() => Goods, (goods) => goods.category)
+  goodsList: Goods[];
 }

--- a/backend/src/entity/Goods.ts
+++ b/backend/src/entity/Goods.ts
@@ -50,7 +50,7 @@ export class Goods {
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
 
-  @ManyToOne(() => Category, (category) => category.id)
+  @ManyToOne(() => Category, (category) => category.goodsList)
   @JoinColumn()
   category: Category;
 

--- a/backend/src/repository/category.repository.ts
+++ b/backend/src/repository/category.repository.ts
@@ -1,4 +1,4 @@
-import { getRepository } from 'typeorm';
+import { getRepository, IsNull, Not } from 'typeorm';
 import { CATEGORY_DB_ERROR } from '../constants/database.error.name';
 import { Category } from '../entity/Category';
 import { DatabaseError } from '../errors/base.error';
@@ -48,11 +48,12 @@ async function getAllCategories(): Promise<Category[]> {
   }
 }
 
-async function getParentCategories(): Promise<Category[]> {
+async function getChildCategories(): Promise<Category[]> {
   try {
     return getRepository(Category).find({
+      relations: ['goodsList'],
       where: {
-        parent: null,
+        parent: Not(IsNull()),
       },
     });
   } catch (err) {
@@ -93,7 +94,7 @@ export const CategoryRepository = {
   createSubCategory,
   getCategoryByName,
   getAllCategories,
-  getParentCategories,
+  getChildCategories,
   getCategoryCountByParentId,
   getParentCategoryNameById,
   getCategoryNameById,

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
-router.get('/dashboard', wrapAsync(CategoryController.getParentCategoryCount));
+router.get('/dashboard/count', wrapAsync(CategoryController.getCategoryCounts));
 router.get('/dashboard/sell', wrapAsync(CategoryController.getTopSellingCategory));
 router.get('/dashboard/view', wrapAsync(CategoryController.getCategoryViews));
 

--- a/backend/src/router/category.router.ts
+++ b/backend/src/router/category.router.ts
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get('/', wrapAsync(CategoryController.getAllCategory));
 router.post('/', wrapAsync(CategoryController.createCategory));
-router.get('/dashboard/count', wrapAsync(CategoryController.getCategoryCounts));
+router.get('/dashboard/count', wrapAsync(CategoryController.getCategoryGoodsCounts));
 router.get('/dashboard/sell', wrapAsync(CategoryController.getTopSellingCategory));
 router.get('/dashboard/view', wrapAsync(CategoryController.getCategoryViews));
 

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -52,7 +52,7 @@ async function getAllCategory(): Promise<CategoryResponse[]> {
   return Array.from(categoryMap.entries()).map(([_, value]) => value);
 }
 
-async function getCategoryCount(): Promise<CategoryCountResponse> {
+async function getCategoryGoodsCount(): Promise<CategoryCountResponse> {
   const childCategories = await CategoryRepository.getChildCategories();
   return childCategories.map((category) => {
     return { name: category.name, value: category.goodsList.length };
@@ -115,7 +115,7 @@ async function pushCategoryViewToList(
 export default {
   createCategory,
   getAllCategory,
-  getCategoryCount,
+  getCategoryGoodsCount,
   getTopSellingCategory,
   getCategoryViews,
 };

--- a/backend/src/service/category.service.ts
+++ b/backend/src/service/category.service.ts
@@ -52,13 +52,11 @@ async function getAllCategory(): Promise<CategoryResponse[]> {
   return Array.from(categoryMap.entries()).map(([_, value]) => value);
 }
 
-async function getParentCategoryCount(): Promise<CategoryCountResponse> {
-  const categoryCountList: CategoryCountResponse = [];
-  const parentCategories = await CategoryRepository.getParentCategories();
-  await Promise.all(
-    parentCategories.map(async (category) => await pushCategoryCountToList(category, categoryCountList))
-  );
-  return categoryCountList;
+async function getCategoryCount(): Promise<CategoryCountResponse> {
+  const childCategories = await CategoryRepository.getChildCategories();
+  return childCategories.map((category) => {
+    return { name: category.name, value: category.goodsList.length };
+  });
 }
 
 async function getTopSellingCategory(): Promise<CategorySellCountResponse> {
@@ -103,14 +101,6 @@ async function getCategoryViews(): Promise<CategoryViewCountResponse> {
   return result;
 }
 
-async function pushCategoryCountToList(category: Category, categoryCountList: CategoryCountResponse): Promise<void> {
-  const count = await CategoryRepository.getCategoryCountByParentId(category.id);
-  categoryCountList.push({
-    name: category.name,
-    value: count,
-  });
-}
-
 async function pushCategoryViewToList(
   categoryId: number,
   view: number,
@@ -125,7 +115,7 @@ async function pushCategoryViewToList(
 export default {
   createCategory,
   getAllCategory,
-  getParentCategoryCount,
+  getCategoryCount,
   getTopSellingCategory,
   getCategoryViews,
 };

--- a/backend/src/types/response/category.response.ts
+++ b/backend/src/types/response/category.response.ts
@@ -22,3 +22,8 @@ export type CategoryResponse = {
   name: string;
   categories?: CategoryResponse[];
 };
+
+export type CategoryRatio = {
+  name: string;
+  count: number;
+};

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -12,7 +12,7 @@ const getAllCategory = async (): Promise<APIResponse<CategoryResponse>> => {
   return res.json();
 };
 
-const getCategoryCounts = async (): Promise<APIResponse<PieChartData>> => {
+const getCategoryGoodsCounts = async (): Promise<APIResponse<PieChartData>> => {
   const res = await checkedFetch(`/api/category/dashboard/count`, {
     method: 'GET',
     credentials: 'include',
@@ -38,7 +38,7 @@ const getCategoriesView = async (): Promise<APIResponse<CategoryView[]>> => {
 
 const CategoryAPI = {
   getAllCategory,
-  getCategoryCounts,
+  getCategoryGoodsCounts,
   getBestSellingCategory,
   getCategoriesView,
 };

--- a/frontend/admin/src/apis/categoryAPI.ts
+++ b/frontend/admin/src/apis/categoryAPI.ts
@@ -12,8 +12,8 @@ const getAllCategory = async (): Promise<APIResponse<CategoryResponse>> => {
   return res.json();
 };
 
-const getParentCategoryCount = async (): Promise<APIResponse<PieChartData>> => {
-  const res = await checkedFetch(`/api/category/dashboard`, {
+const getCategoryCounts = async (): Promise<APIResponse<PieChartData>> => {
+  const res = await checkedFetch(`/api/category/dashboard/count`, {
     method: 'GET',
     credentials: 'include',
   });
@@ -38,7 +38,7 @@ const getCategoriesView = async (): Promise<APIResponse<CategoryView[]>> => {
 
 const CategoryAPI = {
   getAllCategory,
-  getParentCategoryCount,
+  getCategoryCounts,
   getBestSellingCategory,
   getCategoriesView,
 };

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -16,17 +16,23 @@ const CategoryPieChart = () => {
     theme.ChartColorOrange,
   ];
 
-  // const COLORS = ['#2F343A', '#E64A45', '#717D8C', '#BDB69C', '#80CEB9', '#41AAC4', '#462066', '#F2C249', '#E6772E'];
+  const fetchChartData = async () => {
+    try {
+      const { result } = await CategoryAPI.getCategoryCounts();
+      const totalCount = result.reduce((pre, curr) => pre + curr.value, 0);
+      const processedData = result.map(({ name, value }) => {
+        return {
+          name,
+          value: totalCount,
+        };
+      });
+      setChartData(processedData);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   useEffect(() => {
-    async function fetchChartData() {
-      try {
-        const { result } = await CategoryAPI.getParentCategoryCount();
-        setChartData(result);
-      } catch (err) {
-        console.error(err);
-      }
-    }
     fetchChartData();
   }, []);
 

--- a/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
+++ b/frontend/admin/src/pages/Main/CategoryPieChart/CategoryPieChart.tsx
@@ -18,15 +18,8 @@ const CategoryPieChart = () => {
 
   const fetchChartData = async () => {
     try {
-      const { result } = await CategoryAPI.getCategoryCounts();
-      const totalCount = result.reduce((pre, curr) => pre + curr.value, 0);
-      const processedData = result.map(({ name, value }) => {
-        return {
-          name,
-          value: totalCount,
-        };
-      });
-      setChartData(processedData);
+      const { result } = await CategoryAPI.getCategoryGoodsCounts();
+      setChartData(result);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## :bookmark_tabs: 제목

제목 그대로 관리자페이지의 파이차트에서 정확한 상품 수를 출력하도록 수정했습니다.
진행하면서 Category Entitty에서 OneToMany 관계를 통해 Goods를 얻어와서 개수를 얻어내도록 수정했습니다.(코드 수정 최소화)

<img width="1202" alt="스크린샷 2021-08-25 오후 8 29 33" src="https://user-images.githubusercontent.com/20085849/130783068-7c60f4af-ee07-461c-a240-c2dbdbc3f84e.png">


## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Category Entity에 goodsList 라는 컬럼을 추가했습니다.
