### PR TITLE
[feature/250] 주문 완료 후 cart 상태 최신화

### DIFF
--- a/frontend/client/src/pages/Order/OrderPage.tsx
+++ b/frontend/client/src/pages/Order/OrderPage.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { orderState } from '@src/recoil/orderState';
 
 import PageHeader from '@src/components/PageHeader/PageHeader';
@@ -24,6 +24,7 @@ import withLoggedIn from '@src/utils/withLoggedIn';
 import withScrollToTopOnMount from '@src/utils/withScrollToTopOnMount';
 import composeComponent from '@src/utils/composeComponent';
 import theme from '@src/theme/theme';
+import { cartState } from '@src/recoil/cartState';
 
 const NEED_ADDRESS_MESSAGE = '배송지를 입력해주세요!';
 const NEED_PAYMENT_MESSAGE = '결제수단을 선택해주세요!';
@@ -32,6 +33,7 @@ const DEFAULT_ORDER_MEMO = '부재 시 연락바랍니다.';
 
 const OrderPage: React.FC = () => {
   const { goodsList: orderGoodsList, cartIds } = useRecoilValue(orderState);
+  const [carts, setCarts] = useRecoilState(cartState);
   const [selectedAddress, setSelectedAddress] = useState<AddressInfo | null>(null);
   const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(null);
   const [isAgreementChecked, setIsAgreementChecked] = useState(false);
@@ -73,6 +75,7 @@ const OrderPage: React.FC = () => {
     };
 
     await submitOrder(submitOrderBody);
+    if (cartIds) setCarts((currentCarts) => currentCarts.filter((cart) => !cartIds.includes(cart.id)));
     setIsOrdered(true);
   };
 


### PR DESCRIPTION
## https://github.com/woowa-techcamp-2021/store-5/issues/250#issuecomment-906931166 에서 제보된 주문 완료 후 cart 상태 최신화 버그를 해결하였습니다.

### 결과 화면


https://user-images.githubusercontent.com/64543699/131204274-25c197a4-0f8e-4e00-8533-d3ab5d6f4106.mov



### 유의사항

간단한 리코일 상태 수정 코드를 추가했을 뿐입니다.

