### PR TITLE
fix: 메인 상품 리스트 버그 수정

### DIFF
--- a/backend/src/service/goods.service.ts
+++ b/backend/src/service/goods.service.ts
@@ -258,7 +258,7 @@ async function getMainGoodsListMap(userId?: number): Promise<{
   const bestProps: FindAllProps = {
     order: 'countOfSell',
     offset: 0,
-    sort: 'ASC',
+    sort: 'DESC',
     limit: 4,
     stock: 0,
   };
@@ -272,7 +272,7 @@ async function getMainGoodsListMap(userId?: number): Promise<{
   const discountProps: FindAllProps = {
     order: 'discountRate',
     offset: 0,
-    sort: 'ASC',
+    sort: 'DESC',
     limit: 8,
     stock: 0,
   };

--- a/frontend/client/src/pages/Main/Main.tsx
+++ b/frontend/client/src/pages/Main/Main.tsx
@@ -52,8 +52,8 @@ const Main = () => {
         </PromotionContainer>
         <MainContentContainer>
           <GoodsSection sectionTitle='잘나가요' goodsList={mainGoodsListMap.bestGoodsList} itemBoxSize='big' />
-          <GoodsSection sectionTitle='새로 나왔어요' goodsList={mainGoodsListMap.discountGoodsList} itemBoxSize='big' />
-          <GoodsSection sectionTitle='지금 할인 중' goodsList={mainGoodsListMap.latestGoodsList} itemBoxSize='big' />
+          <GoodsSection sectionTitle='새로 나왔어요' goodsList={mainGoodsListMap.latestGoodsList} itemBoxSize='big' />
+          <GoodsSection sectionTitle='지금 할인 중' goodsList={mainGoodsListMap.discountGoodsList} itemBoxSize='big' />
         </MainContentContainer>
         <AdminFubButton />
       </>


### PR DESCRIPTION
## :bookmark_tabs: 제목

메인 상품 리스트 버그 수정

### sort 수정

![image](https://user-images.githubusercontent.com/45394360/131292311-201c219c-056c-48b1-8415-8bc0370b03f9.png)

### 리스트가 뒤바뀐 점 수정

![image](https://user-images.githubusercontent.com/45394360/131292331-b8a354de-2d9a-401d-a0a8-b4d44fa313ad.png)

### 상품 등록 테스트
![녹화_2021_08_30_15_02_59_543](https://user-images.githubusercontent.com/45394360/131292729-7a4f9188-840b-40d9-88e3-a7c2296e0dc6.gif)

## :heavy_check_mark: 셀프 체크리스트

> ~최소 1명 이상의 assign을 받아야만 Merge 가능합니다.~

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] 'npm run lint'나 'yarn lint'를 실행하였나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 잘나가요 리스트의 sort ASC -> DESC
- [x] 지금 할인 중 리스트의 sort ASC -> DESC
- [x]  잘나가요와 지금 할인 중 리스트가 바뀌어 있는 점 수정